### PR TITLE
Update dev suite so it can build NIRES masters automatically 

### DIFF
--- a/build_nires_masters
+++ b/build_nires_masters
@@ -5,7 +5,7 @@
 # -*- coding: utf-8 -*-
 
 """
-This script builds the Cooked folder
+This script builds the NIRES Masters
 Execute it with:   ./build_cooked
 """
 
@@ -28,7 +28,10 @@ def parser(options=None):
     #parser.add_argument('version', type=str, help='Version number to generate (e.g. 0.91)')
     parser.add_argument('--redux_dir', type=str, help='Full path to the REDUX dir; '
                                                       'default is REDUX_OUT in current directory')
-    parser.add_argument('-i', '--ignore_missing', help='Ignore any missing files',
+    parser.add_argument('-o', '--output_dir', type=str,
+                        help='Full path to the destination directory for the NIRES masters.'
+                             'Defaults to "NIRES_MASTERS" in the current directory')
+    parser.add_argument('-f', '--force_copy', help='Copy the files even if they already exist in the destination',
                         action='store_true', default=False)
 
     return parser.parse_args() if options is None else parser.parse_args(options)
@@ -42,17 +45,14 @@ def main():
                     else pargs.redux_dir
 
     # Generate Cooked folder
-    nires_dir = 'NIRES_MASTERS'
-    if not os.path.isdir(nires_dir):
-        os.mkdir(nires_dir)
+    if pargs.output_dir is not None:
+        nires_dir = pargs.output_dir
+    else:
+        nires_dir = 'NIRES_MASTERS'
 
-    # ------------------------------------------------------------------
-    # Version
-    #vfile = os.path.join('Cooked', 'version')
-    # Lines
-    #with open(vfile, 'w') as f:
-    #    f.writelines(lines)
-    # ------------------------------------------------------------------
+    if not os.path.isdir(nires_dir):
+        os.makedirs(nires_dir, exist_ok=True)
+
 
     # ------------------------------------------------------------------
     keck_nires_path = os.path.join(redux_dir, 'keck_nires', 'NIRES', 'Masters')
@@ -60,44 +60,16 @@ def main():
     # Do it
     for ifile in files_01:
         cooked_file = os.path.join(nires_dir, os.path.basename(ifile).replace('_2_','_1_'))
-        copy_me(ifile, cooked_file)
+        copy_me(ifile, cooked_file, pargs.force_copy)
     # A few more
     for root in ['MasterFlat_A_7_01.fits', 'MasterSlits_A_7_01.fits.gz']:
         ifile = os.path.join(keck_nires_path, root)
         cooked_file = os.path.join(nires_dir, os.path.basename(ifile).replace('7','1'))
-        copy_me(ifile, cooked_file)
+        copy_me(ifile, cooked_file, pargs.force_copy)
 
+    exit(0)
 
-
-def copy_with_root(new_root, cooked_root, debug=False, ignore_missing=False):
-    """
-    Copy all files with a given root
-
-    Args:
-        new_root: str
-        cooked_root: str
-        debug:
-
-    Returns:
-
-    """
-    # Grab em
-    new_files = glob.glob(new_root+'.*')
-    if len(new_files) == 0 and not ignore_missing:
-        raise ValueError('No files found with root: {0}'.format(new_root))
-    for new_file in new_files:
-        bname = os.path.basename(new_file)
-        dpos = bname.find('.')
-        exten = bname[dpos:]
-        #
-        cooked_file = cooked_root+exten
-        # Copy
-        if debug:
-            pdb.set_trace()
-        copy_me(new_file, cooked_file)
-
-
-def copy_me(new_file, cooked_file):
+def copy_me(new_file, cooked_file, force_copy):
     """
     Simple script to copy a given file to a new file
     First compares that the new_file is newer than the
@@ -116,7 +88,7 @@ def copy_me(new_file, cooked_file):
         # Time is in seconds total (like MJD)
         if os.path.getctime(cooked_file) > os.path.getctime(new_file):
             doit = False
-    if doit:
+    if doit or force_copy:
         shutil.copy2(new_file, cooked_file)
         print("Generated/over-wrote {:s}".format(cooked_file))
 

--- a/test_scripts/pypeit_tests.py
+++ b/test_scripts/pypeit_tests.py
@@ -32,6 +32,9 @@ class PypeItTest(ABC):
         self.description = description
         self.log_suffix = log_suffix
 
+        self.env = os.environ
+        """ :obj:`Mapping`: OS Environment to run the test under."""
+
         self.passed = None
         """ bool: True if the test passed, False if the test failed, None if the test is in progress"""
 
@@ -84,7 +87,7 @@ class PypeItTest(ABC):
                 try:
                     self.command_line = self.build_command_line()
                     self.start_time = datetime.datetime.now()
-                    child = subprocess.Popen(self.command_line, stdout=f, stderr=f, cwd=self.setup.rdxdir)
+                    child = subprocess.Popen(self.command_line, stdout=f, stderr=f, env=self.env, cwd=self.setup.rdxdir)
                     self.pid = child.pid
                     child.wait()
                     self.end_time = datetime.datetime.now()
@@ -309,10 +312,10 @@ class PypeItTelluricTest(PypeItTest):
         return command_line
 
 class PypeItQuickLookTest(PypeItTest):
-    """Test subclass that runs pypeit_ql_mos"""
+    """Test subclass that runs pypeit_ql* scripts"""
 
     def __init__(self, setup, pargs, files, mos=False):
-        super().__init__(setup, "pypeit_ql_mos", "test_ql")
+        super().__init__(setup, "pypeit_ql", "test_ql")
         self.files = files
         self.mos = mos
 
@@ -322,6 +325,42 @@ class PypeItQuickLookTest(PypeItTest):
 
         return command_line
 
+    def run(self):
+        """Generate any required quick look masters before running the quick look test"""
+
+        if not self.mos:
+
+            try:
+                # Place the masters into the NIRES_MASTERS environment variable if defined, otherwise
+                # default to ${PYPEIT_DEV}/QL/NIRES_MASTERS.  To set that default we set the
+                # NIRES_MASTERS variable in the tests's environment
+                if 'NIRES_MASTERS' in os.environ:
+                    output_dir = os.environ['NIRES_MASTERS']
+                else:
+                    output_dir = os.path.join(self.setup.dev_path, 'QL', 'NIRES_MASTERS')
+                    self.env = os.environ.copy()
+                    self.env['NIRES_MASTERS'] = output_dir
+
+                # Build the masters with the output going to a log file
+                logfile = get_unique_file(os.path.join(self.setup.rdxdir, "build_nires_masters_output.log"))
+                with open(logfile, "w") as log:
+                    result = subprocess.run([os.path.join(self.setup.dev_path, 'build_nires_masters'),
+                                             '--force_copy', '--output_dir', output_dir],
+                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+                    print(result.stdout, file=log)
+
+                if result.returncode != 0:
+                    self.error_msgs.append("Failed to generate NIRES masters.")
+                    return False
+            except Exception:
+                # Prevent any exceptions from escaping the "run" method
+                self.error_msgs.append("Exception building NIRES masters:")
+                self.error_msgs.append(traceback.format_exc())
+                return False
+
+        # Run the quick look test via the parent's run method
+        return super().run()
 
 def pypeit_file_name(instr, setup, std=False):
     base = '{0}_{1}'.format(instr.lower(), setup.lower())
@@ -387,7 +426,7 @@ def get_unique_file(file):
     file_num = 2
     (file_base, file_ext) = os.path.splitext(file)
     while os.path.exists(file):
-        file = f'{file_base}.{file_num}.{file_ext}'
+        file = f'{file_base}.{file_num}{file_ext}'
         file_num += 1
 
     return file


### PR DESCRIPTION
These changes generate the NIRES masters automatically when running a quick look test in the dev suite. The masters will be placed into `$NIRES_MASTERS`, or if that isn't defined, into `$PYPEIT_DEV/QL/NIRES_MASTERS`, meaning that someone running the dev suite does not have to download the masters prior to running, and doesn't have to set the `NIRES_MASTERS` environment variable. 

In addition I cleaned up some unused code in the build_nires_masters script and fixed a bug with log file names. I also updated the unit tests and fixed the unit tests to actually run.