### PR TITLE
Add mmt_bluechannel

### DIFF
--- a/pypeit_files/mmt_bluechannel_300l.pypeit
+++ b/pypeit_files/mmt_bluechannel_300l.pypeit
@@ -1,0 +1,43 @@
+# Auto-generated PypeIt file
+# Mon 02 Nov 2020 18:11:35
+
+# User-defined execution parameters
+[rdx]
+  spectrograph = mmt_bluechannel
+
+# Setup
+setup read
+ Setup A:
+   --:
+     binning: 1,2
+     dichroic: Clear/Clear
+     disperser:
+       angle: none
+       name: 300GPM
+     slit:
+       decker: 5.0x180
+       slitlen: none
+       slitwid: none
+setup end
+
+# Read in the data
+data read
+ path ..
+|        filename |                 frametype |                 ra |                 dec |           target | dispname |  decker | binning |                mjd | airmass | exptime |
+| skyobs0069.fits |                  arc,tilt |  321.9778958333333 |  31.577184444444445 |           henear |   300GPM | 1.0x180 |     1,2 |  58641.49300925926 |     1.0 |   300.0 |
+| skyobs0062.fits |           trace,pixelflat | 320.53355416666665 |   31.57898833333333 |            flats |   300GPM | 5.0x180 |     1,2 |  58641.48900462963 |     1.0 |     3.0 |
+| skyobs0063.fits |           trace,pixelflat |  320.6396291666667 |  31.578857499999998 |            flats |   300GPM | 5.0x180 |     1,2 |  58641.48930555556 |     1.0 |     3.0 |
+| skyobs0064.fits |           trace,pixelflat | 320.74144583333333 |  31.578721388888887 |            flats |   300GPM | 5.0x180 |     1,2 | 58641.489583333336 |     1.0 |     3.0 |
+| skyobs0065.fits |           trace,pixelflat | 320.83479166666666 |   31.57860611111111 |            flats |   300GPM | 5.0x180 |     1,2 | 58641.489849537036 |     1.0 |     3.0 |
+| skyobs0066.fits |           trace,pixelflat |  320.9450833333333 |            31.57847 |            flats |   300GPM | 5.0x180 |     1,2 |  58641.49015046296 |     1.0 |     3.0 |
+| skyobs0001.fits |                   science |  246.9731666666666 |   9.204083333333333 |          G138-31 |   300GPM | 5.0x180 |     1,2 |  58641.31518518519 |     1.1 |   300.0 |
+| skyobs0002.fits |                   science |  246.9731666666666 |   9.204083333333333 |          G138-31 |   300GPM | 5.0x180 |     1,2 | 58641.325694444444 |   1.115 |   300.0 |
+| skyobs0003.fits |                 illumflat | 269.74999999999994 |               31.55 |    sky_az90_el85 |   300GPM | 5.0x180 |     1,2 |  58641.33498842592 |   1.002 |   100.0 |
+| skyobs0004.fits |                 illumflat | 269.74999999999994 |               31.55 |    sky_az90_el85 |   300GPM | 5.0x180 |     1,2 |  58641.33707175926 |   1.002 |   100.0 |
+| skyobs0005.fits |                 illumflat | 269.74999999999994 |               31.55 |    sky_az90_el85 |   300GPM | 5.0x180 |     1,2 | 58641.338472222225 |   1.001 |   100.0 |
+| skyobs0006.fits |                 illumflat | 269.74999999999994 |               31.55 |    sky_az90_el85 |   300GPM | 5.0x180 |     1,2 |  58641.34103009259 |   1.001 |   100.0 |
+| skyobs0007.fits |                 illumflat | 269.74999999999994 |               31.55 |    sky_az90_el85 |   300GPM | 5.0x180 |     1,2 |  58641.34244212963 |     1.0 |   100.0 |
+| skyobs0008.fits |                 illumflat |  8.499999999999998 |             54.4075 |  sky_az37.6_el20 |   300GPM | 5.0x180 |     1,2 |  58641.34719907407 |   2.864 |   100.0 |
+| skyobs0009.fits |                 illumflat |  8.499999999999998 |             54.4075 |  sky_az37.6_el20 |   300GPM | 5.0x180 |     1,2 |  58641.34890046297 |   2.822 |   100.0 |
+data end
+

--- a/test_scripts/test_setups.py
+++ b/test_scripts/test_setups.py
@@ -99,8 +99,8 @@ class TestPhase(Enum):
 
 
 supported_instruments = ['kast', 'deimos', 'kcwi', 'nires', 'nirspec', 'mosfire', 'lris', 'xshooter', 'gnirs', 'gmos',
-                         'flamingos2', 'mage', 'fire', 'luci', 'mdm', 'alfosc', 'fors2', 'binospec', 'mmirs', 'mods',
-                         'dbsp', 'tspec']
+                         'flamingos2', 'mage', 'fire', 'luci', 'mdm', 'alfosc', 'fors2', 'binospec', 'mmirs', 'bluechannel',
+                         'mods', 'dbsp', 'tspec']
 
 
 develop_setups = {'shane_kast_blue': ['452_3306_d57', '600_4310_d55', '830_3460_d46'],
@@ -129,6 +129,7 @@ develop_setups = {'shane_kast_blue': ['452_3306_d57', '600_4310_d55', '830_3460_
                   'mdm_osmos': ['MDM4K'],
                   'mmt_binospec': ['Longslit_G600', 'Multislit_G270'],
                   'mmt_mmirs': ['HK_zJ', 'J_zJ', 'K_K'],
+                  'mmt_bluechannel': ['300l'],
                   'not_alfosc': ['grism4', 'grism19'],
                   'p200_dbsp_blue': ['600_4000_d55'],
                   'p200_dbsp_red': ['316_7500_d55'],


### PR DESCRIPTION
This PR sets up the test configuration for the MMT Blue Channel support added in https://github.com/pypeit/PypeIt/pull/1079. This only covers the 300-line grating because it's what was used during development and is the easiest mode to support. Some 500-line data was shown to work as well, but more grating angle coverage is needed for testing. The 1200 and 832 line gratings will need to use templates for wavelength calibration so will require more calibration data and work.