### PR TITLE
build_cooked for Deimos radec

### DIFF
--- a/build_cooked
+++ b/build_cooked
@@ -77,12 +77,15 @@ def main():
     # Keck KCWI Science files
     keck_kcwi_Science = os.path.join(redux_dir, 'keck_kcwi', 'bh2_4200', 'Science')
     keck_kcwi_files = glob.glob(os.path.join(keck_kcwi_Science, 'spec2d_*fits'))
+     # Keck DEIMOS Science files
+    keck_deimos_Science = os.path.join(redux_dir, 'keck_deimos','830G_M_8500', 'Science')
+    keck_deimos_files = glob.glob(os.path.join(keck_deimos_Science, 'spec1d_DE.20100913*.fits'))
     ''' NOT USED RIGHT NOW
     # DEIMOS standard
     keck_deimos_Science = os.path.join(redux_dir, 'keck_deimos','830G_L_8400', 'Science')
     keck_deimos_files = glob.glob(os.path.join(keck_deimos_Science, 'spec1d_G191*.fits'))
     '''
-    all_files = kastb_files + keck_kcwi_files #+ keck_deimos_files
+    all_files = kastb_files + keck_kcwi_files + keck_deimos_files
     # Generate folder
     cooked_dir = os.path.join('Cooked', 'Science')
     if not os.path.isdir(cooked_dir):

--- a/pypeit_files/keck_deimos_830g_m_8600.pypeit
+++ b/pypeit_files/keck_deimos_830g_m_8600.pypeit
@@ -6,6 +6,9 @@
     detnum = 1,5
 [baseprocess]
     use_biasimage=False
+[calibrations]
+    [[flatfield]]
+        saturated_slits = mask
     
 # Setup
 setup read


### PR DESCRIPTION
I have update `build_cooked` so that will save a DEIMOS 1d spectrum in the Cooked folder. This is needed for an unit test associated with this PR: https://github.com/pypeit/PypeIt/pull/1101