### PR TITLE
Fix auto generation of NIRES masters using a different output dir

### DIFF
--- a/test_scripts/pypeit_tests.py
+++ b/test_scripts/pypeit_tests.py
@@ -318,6 +318,7 @@ class PypeItQuickLookTest(PypeItTest):
         super().__init__(setup, "pypeit_ql", "test_ql")
         self.files = files
         self.mos = mos
+        self.redux_dir = os.path.abspath(pargs.outputdir)
 
     def build_command_line(self):
         command_line = ['pypeit_ql_mos', self.setup.instr] if self.mos else ['pypeit_ql_keck_nires']
@@ -345,7 +346,7 @@ class PypeItQuickLookTest(PypeItTest):
                 logfile = get_unique_file(os.path.join(self.setup.rdxdir, "build_nires_masters_output.log"))
                 with open(logfile, "w") as log:
                     result = subprocess.run([os.path.join(self.setup.dev_path, 'build_nires_masters'),
-                                             '--force_copy', '--output_dir', output_dir],
+                                             '--redux_dir', self.redux_dir, '--force_copy', '--output_dir', output_dir],
                                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
                     print(result.stdout, file=log)

--- a/test_scripts/test_pypeit_test.py
+++ b/test_scripts/test_pypeit_test.py
@@ -331,7 +331,11 @@ def test_main_debug_priority_list(monkeypatch, tmp_path, capsys):
                     if word == last_setup_found:
                         # Don't check against the next test setup if this is a test in the previous test setup
                         continue
-
+                    # If more tests have been added to the debug tests, don't get an index out of
+                    # bound exception
+                    if current_pos >= len(test_order):
+                        break
+                        
                     assert word == test_order[current_pos]
                     last_setup_found = word
                     current_pos += 1


### PR DESCRIPTION
Fixed a bug where auto generating NIRES masters would fail if a different output directory was specified using -o.  Also fixed the unit tests to work when more tests are added to the "--debug" set of tests.