### PR TITLE
Change --pre_only to copy over .pypeit files and and fix directory

### DIFF
--- a/test_scripts/pypeit_tests.py
+++ b/test_scripts/pypeit_tests.py
@@ -111,6 +111,7 @@ class PypeItTest(ABC):
         files generated during testing should be included"""
         return []
 
+
 class PypeItSetupTest(PypeItTest):
     """Test subclass that runs pypeit_setup"""
     def __init__(self, setup, pargs):
@@ -153,17 +154,13 @@ class PypeItReduceTest(PypeItTest):
         super().__init__(setup, description, "test")
 
         self.std = std
-
+        # If the pypeit file isn't being created by pypeit_setup, copy it and update it's path
         if not self.setup.generate_pyp_file:
             self.pyp_file = template_pypeit_file(self.setup.dev_path,
                                                  self.setup.instr,
                                                  self.setup.name,
                                                  self.std)
 
-    def build_command_line(self):
-        if self.setup.generate_pyp_file:
-            self.pyp_file = self.setup.pyp_file
-        else:
             self.pyp_file = fix_pypeit_file_directory(self.pyp_file,
                                                       self.setup.dev_path,
                                                       self.setup.rawdir,
@@ -171,6 +168,10 @@ class PypeItReduceTest(PypeItTest):
                                                       self.setup.name,
                                                       self.setup.rdxdir,
                                                       self.std)
+
+    def build_command_line(self):
+        if self.setup.generate_pyp_file:
+            self.pyp_file = self.setup.pyp_file
 
         command_line = ['run_pypeit', self.pyp_file, '-o']
         if self.masters:
@@ -390,7 +391,7 @@ def fix_pypeit_file_directory(pyp_file, dev_path, raw_data, instr, setup, rdxdir
     """
     # Read the pypeit file
     if not os.path.isfile(pyp_file):
-        raise FileNotFoundError('File does not exist: {0}'.format(pyp_file))
+        raise FileNotFoundError(pyp_file)
     with open(pyp_file, 'r') as infile:
         lines = infile.readlines()
 

--- a/test_scripts/test_pypeit_test.py
+++ b/test_scripts/test_pypeit_test.py
@@ -396,6 +396,7 @@ def test_main_in_steps(monkeypatch, tmp_path):
         monkeypatch.setattr(sys, "argv", ['pypeit_test', '-o', str(tmp_path), '-t', '4',
                                           '-i', 'shane_kast_blue', '--prep_only', '-s', '600_4310_d55', 'develop'])
         assert test_main.main() == 0
+        assert (tmp_path / "shane_kast_blue" / "452_3306_d57" / "shane_kast_blue_452_3306_d57.pypeit").exists()
 
         monkeypatch.setattr(sys, "argv", ['pypeit_test', '-o', str(tmp_path), '-t', '4',
                                           '-i', 'shane_kast_blue', '-s', '600_4310_d55', 'reduce'])


### PR DESCRIPTION
Changed `build_test_setup` to always create a test instance, so that the `__init__` method can run any prep_only work. I also moved the `fix_pypeit_file_directory` into the `PypeItReduceTest` `init` method so that it will be included in this.

The call to `file_pypeit_file_directory` will raise an exception if a file is missing. To preserve the existing missing files functionality I reorganized it so that it's done in `build_test_setup`, allowing the exception to be caught and the file added to the list.

I also updated the unit tests to check for the .pypeit files being copied in the --prep_only test.