### PR TITLE
add ntt_efosc2

### DIFF
--- a/pypeit_files/ntt_efosc2_gr5_g4target3.pypeit
+++ b/pypeit_files/ntt_efosc2_gr5_g4target3.pypeit
@@ -1,0 +1,37 @@
+# Auto-generated PypeIt file
+# Mon 24 May 2021 16:35:06
+
+# User-defined execution parameters
+[rdx]
+spectrograph = ntt_efosc2
+
+# Setup
+setup read
+    Setup A:
+        dispname: Gr6
+          decker: slit1.0
+         binning: 2,2
+         datasec: [1:2048,:2048]
+setup end
+
+# Read in the data
+data read
+ path /Users/tang/Documents/observation/NTT/data/test/Gr5/G4_TARGET3
+|                           filename |                 frametype |         ra |       dec |     target |  dispname |     decker | binning |            mjd | airmass |  exptime |        datasec |
+| EFOSC.2020-02-12T01:24:31.967.fits |                  arc,tilt |  99.579335 | -48.98692 |       WAVE |       Gr6 |    slit1.0 |     2,2 | 58891.05870332 |   1.068 |   2.0059 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:41:26.099.fits |                      bias | 201.182711 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40377429 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:41:57.171.fits |                      bias | 201.182711 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40413392 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:42:27.392.fits |                      bias | 201.182711 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 |  58890.4044837 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:42:58.173.fits |                      bias | 201.182711 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40483997 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:43:28.406.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40518988 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:43:59.167.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40554591 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:44:29.439.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40589628 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:45:00.140.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40625162 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:45:31.132.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40661032 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:46:02.164.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40696949 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-12T01:22:24.238.fits | pixelflat,illumflat,trace |  99.579335 | -48.98692 |       FLAT |       Gr6 |    slit1.0 |     2,2 | 58891.05722498 |   1.069 |   13.203 | [1:2048,:2048] |
+| EFOSC.2020-02-12T01:03:49.815.fits |                   science |  99.579335 | -48.98692 | G4_target1 |       Gr6 |    slit1.0 |     2,2 | 58891.04432656 |   1.079 | 300.0031 | [1:2048,:2048] |
+| EFOSC.2020-02-12T01:09:24.092.fits |                   science |  99.579335 | -48.98692 | G4_target1 |       Gr6 |    slit1.0 |     2,2 | 58891.04819551 |   1.076 |  300.003 | [1:2048,:2048] |
+| EFOSC.2020-02-12T01:14:58.099.fits |                   science |  99.579335 | -48.98692 | G4_target1 |       Gr6 |    slit1.0 |     2,2 | 58891.05206133 |   1.073 | 300.0031 | [1:2048,:2048] |
+data end
+

--- a/pypeit_files/ntt_efosc2_gr6_g4target3.pypeit
+++ b/pypeit_files/ntt_efosc2_gr6_g4target3.pypeit
@@ -1,0 +1,37 @@
+# Auto-generated PypeIt file
+# Mon 24 May 2021 16:32:41
+
+# User-defined execution parameters
+[rdx]
+spectrograph = ntt_efosc2
+
+# Setup
+setup read
+    Setup A:
+        dispname: Gr6
+          decker: slit1.0
+         binning: 2,2
+         datasec: [1:2048,:2048]
+setup end
+
+# Read in the data
+data read
+ path /Users/tang/Documents/observation/NTT/data/test/Gr6/G4_TARGET3
+|                           filename |                 frametype |         ra |       dec |     target |  dispname |     decker | binning |            mjd | airmass |  exptime |        datasec |
+| EFOSC.2020-02-12T02:05:46.459.fits |                  arc,tilt | 118.173044 | -54.85474 |       WAVE |       Gr6 |    slit1.0 |     2,2 | 58891.08734327 |   1.133 |   2.0064 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:41:26.099.fits |                      bias | 201.182711 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40377429 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:41:57.171.fits |                      bias | 201.182711 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40413392 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:42:27.392.fits |                      bias | 201.182711 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 |  58890.4044837 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:42:58.173.fits |                      bias | 201.182711 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40483997 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:43:28.406.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40518988 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:43:59.167.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40554591 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:44:29.439.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40589628 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:45:00.140.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40625162 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:45:31.132.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40661032 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-11T09:46:02.164.fits |                      bias |  201.18271 | -47.33147 |       BIAS | Foc_Wedge | Holes_Mask |     2,2 | 58890.40696949 |     1.0 |      0.0 | [1:2048,:2048] |
+| EFOSC.2020-02-12T02:03:38.359.fits | pixelflat,illumflat,trace | 118.173044 | -54.85474 |       FLAT |       Gr6 |    slit1.0 |     2,2 | 58891.08586064 |   1.135 |  13.2032 | [1:2048,:2048] |
+| EFOSC.2020-02-12T01:34:11.847.fits |                   science | 118.173044 | -54.85474 | G4_target3 |       Gr6 |    slit1.0 |     2,2 |  58891.0654149 |   1.165 | 300.0033 | [1:2048,:2048] |
+| EFOSC.2020-02-12T01:39:47.625.fits |                   science | 118.173044 | -54.85474 | G4_target3 |       Gr6 |    slit1.0 |     2,2 | 58891.06930122 |   1.158 | 300.0031 | [1:2048,:2048] |
+| EFOSC.2020-02-12T01:45:22.073.fits |                   science | 118.173044 | -54.85474 | G4_target3 |       Gr6 |    slit1.0 |     2,2 | 58891.07317214 |   1.152 | 300.0031 | [1:2048,:2048] |
+data end
+

--- a/test_scripts/test_setups.py
+++ b/test_scripts/test_setups.py
@@ -101,7 +101,7 @@ class TestPhase(Enum):
 
 supported_instruments = ['kast', 'deimos', 'kcwi', 'nires', 'nirspec', 'mosfire', 'lris', 'xshooter', 'gnirs', 'gmos',
                          'flamingos2', 'mage', 'fire', 'luci', 'mdm', 'alfosc', 'fors2', 'binospec', 'mmirs', 'bluechannel',
-                         'mods', 'dbsp', 'tspec', 'bc']
+                         'mods', 'dbsp', 'tspec', 'bc', 'efosc2']
 
 
 develop_setups = {'bok_bc': ['600'],
@@ -131,6 +131,7 @@ develop_setups = {'bok_bc': ['600'],
                   'mmt_binospec': ['Longslit_G600', 'Multislit_G270'],
                   'mmt_mmirs': ['HK_zJ', 'J_zJ', 'K_K'],
                   'mmt_bluechannel': ['300l'],
+                  'ntt_efosc2': ['gr5_g4target3', 'gr6_g4target3'],
                   'not_alfosc': ['grism4', 'grism19'],
                   'p200_dbsp_blue': ['600_4000_d55'],
                   'p200_dbsp_red': ['316_7500_d55'],


### PR DESCRIPTION
This is a parallel PR to PR #1180 of the main repo. I added the test pypeit file of NTT/EFOSC2.