### PR TITLE
Add method to run test for setups needed to build cooked

### DIFF
--- a/pypeit_files/keck_deimos_1200g_m_5500.pypeit
+++ b/pypeit_files/keck_deimos_1200g_m_5500.pypeit
@@ -7,7 +7,7 @@
      detnum=2
 [calibrations]
      [[slitedges]]
-        edge_thresh = 10.0
+        edge_thresh = 5.0
     [[wavelengths]]
         lamps = NeI, ArI, CdI, KrI, XeI, HgI, ZnI
      [[tilts]]

--- a/test_scripts/test_main.py
+++ b/test_scripts/test_main.py
@@ -21,6 +21,7 @@ from IPython import embed
 import numpy as np
 
 from .test_setups import TestPhase, all_tests, develop_setups, supported_instruments
+from .test_setups import cooked_setups
 from .pypeit_tests import get_unique_file
 
 test_run_queue = PriorityQueue()
@@ -540,6 +541,9 @@ def main():
     devsetups = develop_setups
     tests_that_only_use_dev_setups = ['develop', 'reduce', 'afterburn', 'ql']
 
+    # Cooked instruments (in returned dictonary keys) and setups
+    cooksetups = cooked_setups
+
     # Setup
     unsupported = []
     if pargs.tests == 'all':
@@ -554,6 +558,9 @@ def main():
             flg_after = True
         elif pargs.tests == 'ql':
             flg_ql = True
+    elif pargs.tests.lower() == 'cooked':
+        instruments = np.array(list(cooksetups.keys())) if pargs.instrument is None \
+                        else np.array([pargs.instrument])
     else:
         instruments = np.array([item for item in all_instruments 
                                     if pargs.tests.lower() in item.lower()])
@@ -574,7 +581,6 @@ def main():
             print("\x1B[" + "1;33m" + "\nWARNING - " + "\x1B[" + "0m" +
                   "The following tests have not been validated and may not pass: {0}\n\n".format(
                   unsupported))
-
 
     # Report
     if not pargs.quiet:
@@ -609,6 +615,8 @@ def main():
         # Limit to development setups
         elif pargs.tests in tests_that_only_use_dev_setups:
             setup_names = devsetups[instr]
+        elif pargs.tests.lower() == 'cooked':
+            setup_names = cooksetups[instr]
 
         # Build test setups, check for missing files, and run any prep work
         for setup_name in setup_names:

--- a/test_scripts/test_setups.py
+++ b/test_scripts/test_setups.py
@@ -145,6 +145,15 @@ develop_setups = {'bok_bc': ['600'],
                   'vlt_sinfoni': ['K_0.8'],
                   }
 
+# The instruments/setups needed to build cooked.
+cooked_setups = {'shane_kast_blue': ['600_4310_d55'],
+                  'keck_kcwi': ['bh2_4200'],
+                  'keck_deimos': ['830G_M_8500'],
+                  'shane_kast_red': ['600_7500_d55_ret'],
+                  'keck_lris_red': ['long_600_7500_d560', 'multi_400_8500_d560'],
+                  'keck_lris_blue': ['long_600_4000_d560', 'multi_600_4000_d560'],
+                }
+
 _pypeit_setup = ['shane_kast_blue/600_4310_d55']
 
 _additional_reduce = {'keck_lris_red':


### PR DESCRIPTION
As titled.  Also pairs with https://github.com/pypeit/PypeIt/pull/1237 .  Specifically needed to edit a Keck DEIMOS pypeit file to lower the edge detection threshold.