### PR TITLE
coadd2d files

### DIFF
--- a/coadd2d_files/gemini_gnirs_32_sb_sxd.coadd2d
+++ b/coadd2d_files/gemini_gnirs_32_sb_sxd.coadd2d
@@ -1,0 +1,19 @@
+# Auto-generated PypeIt file
+# Tue 18 Dec 2018 17:01:48
+
+# User-defined execution parameters
+[rdx]
+spectrograph = gemini_gnirs
+[coadd2d]
+   offsets = auto
+   weights = auto
+   user_obj = 1
+
+# Read in the data
+spec2d read
+Science/spec2d_cN20170331S0216-pisco_GNIRS_20170331T085412.181.fits
+Science/spec2d_cN20170331S0217-pisco_GNIRS_20170331T085933.097.fits
+Science/spec2d_cN20170331S0220-pisco_GNIRS_20170331T091538.731.fits
+Science/spec2d_cN20170331S0221-pisco_GNIRS_20170331T092059.597.fits
+spec2d end
+

--- a/coadd2d_files/keck_deimos_830g_m_9000_dither.coadd2d
+++ b/coadd2d_files/keck_deimos_830g_m_9000_dither.coadd2d
@@ -9,6 +9,8 @@
 
 [coadd2d]
   offsets = maskdef_offsets
+  weights = auto
+  user_obj = 1305,1
 
 
 # Read in the data

--- a/coadd2d_files/keck_lris_blue_multi_600_4000_d560.coadd2d
+++ b/coadd2d_files/keck_lris_blue_multi_600_4000_d560.coadd2d
@@ -9,6 +9,11 @@
 [reduce]
     [[findobj]]
         sig_thresh=5.0
+[coadd2d]
+   offsets = auto
+   weights = auto
+
+
 
 # Read in the data
 spec2d read

--- a/coadd2d_files/keck_mosfire_long2pos1_h.coadd2d
+++ b/coadd2d_files/keck_mosfire_long2pos1_h.coadd2d
@@ -1,0 +1,16 @@
+# Auto-generated PypeIt file using PypeIt version: 1.8.2.dev54+gec6efc982
+# 2022-04-11
+
+# User-defined execution parameters
+[rdx]
+spectrograph = keck_mosfire
+
+[coadd2d]
+  offsets = maskdef_offsets
+  weights = 1.,1.
+
+spec2d read
+Science/spec2d_MF.20180718.22100-HIP61138_MOSFIRE_20180718T060820.621.fits
+Science/spec2d_MF.20180718.22154-HIP61138_MOSFIRE_20180718T060914.170.fits
+spec2d end
+

--- a/test_scripts/test_setups.py
+++ b/test_scripts/test_setups.py
@@ -217,12 +217,14 @@ _coadd1d = ['shane_kast_blue/600_4310_d55',
             ]
 
 _coadd2d = {'gemini_gnirs/32_SB_SXD':
-                {'obj': 'pisco'},
+                {'coadd_file': True},
             'keck_lris_blue/multi_600_4000_d560':
                 {'coadd_file': True},
             'vlt_xshooter/VIS_manual':
                 {'coadd_file': True},
             'keck_deimos/830G_M_9000_dither':
+                {'coadd_file': True},
+            'keck_mosfire/long2pos1_H':
                 {'coadd_file': True}
             }
 


### PR DESCRIPTION
Added example of coadd2d. The cases tested are:

`offset` is a list and `weights = uniform`  --> vlt_xshooter_vis_manual

`offsets = maskdef_offsets` and `weights` is a list --> keck_mosfire_long2pos1_h

`offsets = auto` and `weights = auto`  -->keck_lris_blue_multi_600_4000_d560

`offsets = maskdef_offsets` and `weights = auto` and `user_obj` provided (multislit) --> keck_deimos_830g_m_9000_dither

`offsets = auto` and `weights = auto` and `user_obj` provided (echelle)  --> gemini_gnirs_32_sb_sxd