### PR TITLE
Update nires unit tests for a change in the raw data

### DIFF
--- a/unit_tests/test_load_images.py
+++ b/unit_tests/test_load_images.py
@@ -39,7 +39,7 @@ def test_load_lris():
 
 def test_load_nires():
     ifile = os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 'keck_nires', 'NIRES',
-                         's180604_0004.fits.gz')
+                         's190519_0059.fits')
     try:
         # First amplifier
         data_img = grab_img('keck_nires', ifile)

--- a/unit_tests/test_scienceimage.py
+++ b/unit_tests/test_scienceimage.py
@@ -35,15 +35,13 @@ def shane_kast_blue_sci_files():
 def nires_sci_files():
     return [os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 
                          'keck_nires', 'NIRES', ifile)
-            for ifile in ['s180604_0089.fits.gz', 
-                          's180604_0092.fits.gz']]
+            for ifile in ['s190519_0060.fits']]
 
 @pytest.fixture
 def nires_bg_files():
     return [os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 
                          'keck_nires', 'NIRES', ifile)
-            for ifile in ['s180604_0090.fits.gz', 
-                          's180604_0091.fits.gz']]
+            for ifile in ['s190519_0059.fits']]
 
 
 def test_proc_diff(nires_sci_files, nires_bg_files):


### PR DESCRIPTION
Change test_load_images and test_science_image to match the new RAW_DATA structure.