### PR TITLE
Disable flexure for test giving intermittant failures

### DIFF
--- a/pypeit_files/gemini_gmos_gn_e2v_multi_r400_600.pypeit
+++ b/pypeit_files/gemini_gmos_gn_e2v_multi_r400_600.pypeit
@@ -7,6 +7,8 @@ spectrograph = gemini_gmos_north_e2v
 [calibrations]
     [[tilts]]
         tracethresh = 10.
+[flexure]
+   spec_method = skip
 
 # Setup
 setup read


### PR DESCRIPTION
Workaround fix to disable flexture correction due to intermittent Gemini gmos dev-suite failures.

I ran this several times locally and in the cloud to verify the failure no longer occurs.