### PR TITLE
Add a `calibs` test option

### DIFF
--- a/test_scripts/test_main.py
+++ b/test_scripts/test_main.py
@@ -739,6 +739,7 @@ def main():
 
     flg_pypeit_tests = False
     flg_unit = False
+    flg_calibs = False
     flg_reduce = False
     flg_after = False
     flg_ql = False
@@ -763,6 +764,8 @@ def main():
             flg_pypeit_tests = True
         elif test == "unit":
             flg_unit = True
+        elif test == "calibs":
+            flg_calibs = True
         elif test == "reduce":
             flg_reduce = True
         elif test == "after" or test=="afterburn":
@@ -825,8 +828,10 @@ def main():
                 print('Running unit tests in pypeit/tests')
             if flg_unit:
                 print('Running dev suite unit tests')
+            if flg_calibs:
+                print('Running calibration tests')
             if flg_reduce:
-                print('Running reduce tests.')
+                print('Running reduce tests')
             if flg_after:
                 print('Running afterburner tests')
             if flg_ql is True:
@@ -852,7 +857,7 @@ def main():
         run_pytest(pargs, "Unit Tests", os.path.join(dev_path, "unit_tests"), test_report)
 
 
-    if flg_reduce or flg_after or flg_ql:
+    if flg_calibs or flg_reduce or flg_after or flg_ql:
         # ---------------------------------------------------------------------------
         # Build the TestSetup and PypeItTest objects for testing
 
@@ -891,7 +896,7 @@ def main():
             # Build test setups, check for missing files, and run any prep work
             for setup_name in setup_names:
 
-                setup = build_test_setup(pargs, instr, setup_name, flg_reduce, flg_after,
+                setup = build_test_setup(pargs, instr, setup_name, flg_calibs, flg_reduce, flg_after,
                                         flg_ql)
                 missing_files += setup.missing_files
 
@@ -978,27 +983,30 @@ def main():
     return test_report.num_failed
 
 
-def build_test_setup(pargs, instr, setup_name, flg_reduce, flg_after, flg_ql):
+def build_test_setup(pargs, instr, setup_name, flg_calibs, flg_reduce, flg_after, flg_ql):
     """
     Builds a TestSetup object including the tests that it will run
 
     Args:
-        pargs (:obj:`argparse.Namespace`): 
+        pargs (:obj:`argparse.Namespace`):
             The arguments to pypeit_test, as returned by argparse.
         
-        instr (str): 
+        instr (str):
             The instrument the setup is for.
 
-        setup_name (str): 
+        setup_name (str):
             The name of the test setup.
 
-        flg_reduce (bool): 
+        flg_calibs (bool):
+            Whether or not calibration-only tests are being run.
+
+        flg_reduce (bool):
             Whether or not reduce tests are being run.
 
-        flg_after (bool): 
+        flg_after (bool):
             Whether or not afterburner tests are being run.
 
-        flg_ql (bool): 
+        flg_ql (bool):
             Whether or not quick look tests are being run.
 
     Returns:
@@ -1052,6 +1060,9 @@ def build_test_setup(pargs, instr, setup_name, flg_reduce, flg_after, flg_ql):
 
             # Skip the test if it wasn't selected by the command line
             if pargs.prep_only and test_descr['type'] != TestPhase.PREP:
+                continue
+
+            if not flg_calibs and test_descr['type'] == TestPhase.CALIBS:
                 continue
 
             if not flg_reduce and test_descr['type'] == TestPhase.REDUCE:

--- a/test_scripts/test_setups.py
+++ b/test_scripts/test_setups.py
@@ -87,12 +87,14 @@ class TestPhase(Enum):
     Values:
 
     PREP
+    CALIBS
     REDUCE
     AFTERBURN
     QL
     UNIT
     """
     PREP      = auto()
+    CALIBS    = auto()
     REDUCE    = auto()
     AFTERBURN = auto()
     QL        = auto()
@@ -435,6 +437,9 @@ _quick_look = {
 all_tests = [{'factory': pypeit_tests.PypeItSetupTest,
               'type':    TestPhase.PREP,
               'setups':  _pypeit_setup},
+             {'factory': pypeit_tests.PypeItCalibsTest,
+              'type':    TestPhase.CALIBS,
+              'setups':  _reduce_setups},
              {'factory': pypeit_tests.PypeItReduceTest,
               'type':    TestPhase.REDUCE,
               'setups':  _reduce_setups},


### PR DESCRIPTION
In investigating the effects on multiple instruments' wavelength solutions of adding new arc lines, I found it useful to hack in a `calibs` test here to run just `run_pypeit -c` on the various setups, and not the full science reductions.

As it stands, the `calibs` option lies (I think) outside the `all` category, and will only be run when specifically requested.  It _could_ be included in the main workflow before the `reduce` tests to allow easier distinction between failures caused by calibration issues versus science reduction issues -- this is a question that needs discussion from those more familiar with the DevSuite.

As I hacked this together from copying the `reduce` option and tweaking things until it worked, it will need careful review from those more familiar with the DevSuite to ensure I didn't miss something important.