### PR TITLE
Add a setup to test_setups which automatically add calib_id, bkg_id, and comb_id

### DIFF
--- a/unit_tests/test_setups.py
+++ b/unit_tests/test_setups.py
@@ -351,6 +351,11 @@ def test_setup_magellan_mage():
     setup = '1x1'
     generic_setup_test(spec, setup)
 
+def test_setup_magellan_fire():
+    spec = 'magellan_fire'
+    setup = 'FIRE'
+    generic_setup_test(spec, setup)
+
 
 def test_setup_wht_isis_blue():
     spec = 'wht_isis_blue'


### PR DESCRIPTION
This adds a test to test_setup.py in which the spectrograph includes "calib_id", "bkg_id", and "comb_id" in it's set of keys for the pypeit file. This will catch the issue fixed in PypeIt PR [1606](https://github.com/pypeit/PypeIt/pull/1606)

This should not be merged until PR 1601 has been merged in the main pypeit repository.