### PR TITLE
Lris red mark4 masks

### DIFF
--- a/pypeit_files/keck_lris_red_mark4_multi_600_10000_slitmask.pypeit
+++ b/pypeit_files/keck_lris_red_mark4_multi_600_10000_slitmask.pypeit
@@ -1,0 +1,42 @@
+# Auto-generated PypeIt input file using PypeIt version: 1.12.3.dev7+ga9075153d
+# UTC 2023-05-08T19:54:58.446
+
+# User-defined execution parameters
+[rdx]
+    spectrograph = keck_lris_red_mark4
+[baseprocess]
+    use_biasimage = False
+[calibrations]
+ [[slitedges]]
+   use_maskdesign = True
+[reduce]
+ [[slitmask]]
+    use_alignbox = False
+    assign_obj = True
+    extract_missing_objs = True
+  [[findobj]]
+    snr_thresh = 3.0
+  [[extraction]]
+    use_2dmodel_mask = False
+
+# Setup
+setup read
+Setup X:
+  amp: '4'
+  binning: 2,2
+  cenwave: 8081.849304
+  decker: frb22022
+  dichroic: '680'
+  dispangle: 29.418736
+  dispname: 600/10000
+setup end
+
+# Data block 
+data read
+ path r
+                        filename |                 frametype |                 ra |                 dec |     target |  dispname |   decker | binning |          mjd | airmass |       exptime | dichroic | dispangle |     cenwave | amp | frameno
+              r230417_01064.fits |                  arc,tilt | 229.99999999999997 |                45.0 | DOME FLATS | 600/10000 | frb22022 |     2,2 | 60051.725892 |    1.41 |   1.000125952 |      680 | 29.417606 | 8081.269988 |   4 |    1064
+r230417_01072_with_maskinfo.fits | pixelflat,illumflat,trace | 229.99999999999997 |                45.0 | DOME FLATS | 600/10000 | frb22022 |     2,2 | 60051.729634 |    1.41 |  10.000135168 |      680 | 29.417606 | 8081.269988 |   4 |    1072
+              r230417_01033.fits |                   science |          203.90275 | -28.032416666666666 |   frb22022 | 600/10000 | frb22022 |     2,2 | 60051.349105 |    1.71 | 500.000625152 |      680 | 29.418736 | 8081.849304 |   4 |    1033
+data end
+

--- a/test_scripts/test_setups.py
+++ b/test_scripts/test_setups.py
@@ -128,7 +128,7 @@ all_setups  = {
                       'multi_400_8500_d560', 'long_600_10000_d680',
                       'long_400_8500_longread'],  # Longslit read-out mode
     'keck_lris_red_orig': ['long_300_5000'],
-    'keck_lris_red_mark4': ['long_400_8500_d560', 'long_600_10000_d680'],
+    'keck_lris_red_mark4': ['long_400_8500_d560', 'long_600_10000_d680', 'multi_600_10000_slitmask'],
     'lbt_luci': ['LUCI-I', 'LUCI-II'],
     'lbt_mods': ['MODS1R_Longslit', 'MODS2R_Longslit'],
     'ldt_deveny': ['DV1', 'DV2', 'DV3', 'DV4', 'DV5', 'DV6', 'DV7', 'DV8', 'DV9'],

--- a/vet_tests/test_slitmask.py
+++ b/vet_tests/test_slitmask.py
@@ -227,7 +227,7 @@ def test_deimosslitmask():
     assert spec.slitmask.nslits == 106, 'Incorrect number of slits read!'
 
 
-def test_lris_slitmask(redux_out):
+def test_lris_blue_slitmask(redux_out):
     # Check that the LRIS slitmask was read in and used!
     file_path = os.path.join(redux_out,
                              'keck_lris_blue', 
@@ -241,6 +241,22 @@ def test_lris_slitmask(redux_out):
     assert len(specObjs.MASKDEF_ID) > 0
     assert 'gal21' in specObjs.MASKDEF_OBJNAME
     assert 'gal49' in specObjs.MASKDEF_OBJNAME # This was "manually" extracted
+
+def test_lris_red_mark4_slitmask(redux_out):
+    # Check that the LRIS slitmask was read in and used!
+    file_path = os.path.join(redux_out,
+                             'keck_lris_red_mark4', 
+                             'multi_600_10000_slitmask',
+                             'Science', 
+                             'spec1d_r230417_01033-frb22022_LRISr_20230417T082242.672.fits')
+    # Load                                
+    specObjs = specobjs.SpecObjs.from_fitsfile(file_path)
+
+    # Test
+    assert len(specObjs.MASKDEF_ID) > 0
+    assert 'gal172' in specObjs.MASKDEF_OBJNAME # Left-most slit
+    assert 'gal124' in specObjs.MASKDEF_OBJNAME # Right-most slit
+    assert 'FRBCoord' in specObjs.MASKDEF_OBJNAME # Forced extraction for faint source.
 
 def test_gmos_slitmask(redux_out):
     # Check we have sensible RA, Dec


### PR DESCRIPTION
Added `reduce` and `vet` tests for the Mark4 LRISr detector. Worked locally with `pytest`. Modeled the vet test after the one for the blue side detector. Raw files are in the [Google drive](https://drive.google.com/drive/folders/12PP0eIt6qv5CinuRID2QTKd32tm-2CHA?usp=drive_link). 