### PR TITLE
Minor fix for new calibration naming scheme

### DIFF
--- a/sensfunc_files/gemini_gmos_gs_ham_r400_860.sens
+++ b/sensfunc_files/gemini_gmos_gs_ham_r400_860.sens
@@ -1,4 +1,4 @@
 [sensfunc]
   polyorder = 10
   algorithm = IR
-  flatfile = Calibrations/Flat_A_1-2_MSC01.fits
+  flatfile = Calibrations/Flat_A_1+2_MSC01.fits


### PR DESCRIPTION
As titled.

Needed to fix afterburn tests associated with https://github.com/pypeit/PypeIt/pull/1641.