### PR TITLE
Update nautilus yaml for the new image caching scheme.

### DIFF
--- a/nautilus/kube_dev_suite.yaml
+++ b/nautilus/kube_dev_suite.yaml
@@ -29,7 +29,7 @@ spec:
           value: http://rook-ceph-rgw-nautiluss3.rook
         - name: S3_ENDPOINT
           value: rook-ceph-rgw-nautiluss3.rook
-        image: localhost:30081/profxj/pypeit_v1:latest
+        image: docker.io/profxj/pypeit_v1@sha256:a2f91f18fb33119a7f08d804dd3259118e0e934612c3868df58f434e3d980740
         imagePullPolicy: Always
         name: container
         resources:


### PR DESCRIPTION
Nautilus has changed how they cache container images, now a direct URL with SHA hash is the preferred method.  I've updated the dev-suite to do this.