### PR TITLE
Run update_docs when running the dev-suite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,7 @@ reduce        Runs the reduction tests that call run_pypeit directly.
 afterburn     Runs the PypeIt tests that directly call PypeIt post-reduction  tools (e.g. flux calibration, coadding, etc).
 ql            Runs the Quick Look tests.
 vet           Runs the pytest tests that verify the results from earlier PypeIt tests.
+docs          Runs the ``update_docs`` script to verify that PypeIt docs can be generated without errors or warnings.
 all           Runs all of the above, in the order listed above.
 list          This does not run any tests, instead it lists all of the supported instruments and setups. (See below).
 ============= ==============================================================================================================
@@ -442,9 +443,9 @@ Additional Options
 
     $ $PYPEIT_DEV/pypeit_test -h
     usage: pypeit_test [-h] [-o OUTPUTDIR] [-i INSTRUMENTS [INSTRUMENTS ...]]
-                   [-s SETUPS [SETUPS ...]] [--debug] [-p] [-m] [-t THREADS]
-                   [-q] [-v] [--coverage COVERAGE] [-r REPORT] [-c CSV] [-w]
-                   tests [tests ...]
+                       [-s SETUPS [SETUPS ...]] [--debug] [-p] [-m] [-t THREADS]
+                       [-q] [-v] [--coverage COVERAGE] [-r REPORT] [-c CSV] [-w]
+                       tests [tests ...]
 
     Run pypeit tests on a set of instruments. Typical call for testing pypeit when
     developing new code is `./pypeit_test all`. Execution requires you to have a
@@ -456,43 +457,43 @@ Additional Options
     'afterburn''. Use 'list' to view all supported setups.
 
     positional arguments:
-    tests                 Which test types to run. Options are: pypeit_tests,
-                            unit, reduce, afterburn, ql, vet, or all. Use list to
-                            show all supported instruments and setups.
+    tests               Which test types to run. Options are: pypeit_tests,
+                        unit, reduce, afterburn, ql, vet, docs, or all. Use
+                        list to show all supported instruments and setups.
 
-    optional arguments:
+    options:
     -h, --help            show this help message and exit
     -o OUTPUTDIR, --outputdir OUTPUTDIR
-                            Output folder. (default: REDUX_OUT)
+                          Output folder. (default: REDUX_OUT)
     -i INSTRUMENTS [INSTRUMENTS ...], --instruments INSTRUMENTS [INSTRUMENTS ...]
-                            One or more instruments to run tests for. Use
-                            "pypeit_test list" to see all supported instruments.
-                            (default: None)
+                          One or more instruments to run tests for. Use
+                          "pypeit_test list" to see all supported instruments.
+                          (default: None)
     -s SETUPS [SETUPS ...], --setups SETUPS [SETUPS ...]
-                            One or more setups to run tests for. Use "pypeit_test
-                            list" to see all supported setups. (default: None)
+                          One or more setups to run tests for. Use "pypeit_test
+                          list" to see all supported setups. (default: None)
     --debug               Debug using only blue setups (default: False)
     -p, --prep_only       Only prepare to execute run_pypeit, but do not
-                            actually run it. (default: False)
+                          actually run it. (default: False)
     -m, --do_not_reuse_calibs
-                            run pypeit without using any existing calibrations
-                            (default: False)
+                          run pypeit without using any existing processed
+                          calibration frames (default: False)
     -t THREADS, --threads THREADS
-                            Run THREADS number of parallel tests. (default: 1)
+                          Run THREADS number of parallel tests. (default: 1)
     -q, --quiet           Supress all output to stdout. If -r is not a given, a
-                            report file will be written to
-                            <outputdir>/pypeit_test_results.txt (default: False)
+                          report file will be written to
+                          <outputdir>/pypeit_test_results.txt (default: False)
     -v, --verbose         Output additional detailed information while running
-                            the tests and output a detailed report at the end of
-                            testing. This has no effect if -q is given (default:
-                            False)
+                          the tests and output a detailed report at the end of
+                          testing. This has no effect if -q is given (default:
+                          False)
     --coverage COVERAGE   Collect code coverage information. and write it to the
-                            given file. (default: None)
+                          given file. (default: None)
     -r REPORT, --report REPORT
-                            Write a detailed test report to REPORT. (default:
-                            None)
+                          Write a detailed test report to REPORT. (default:
+                          None)
     -c CSV, --csv CSV     Write performance numbers to a CSV file. (default:
-                            None)
+                          None)
     -w, --show_warnings   Show warnings when running unit tests and vet tests.
-                            (default: False)
+                          (default: False)
 

--- a/test_scripts/test_main.py
+++ b/test_scripts/test_main.py
@@ -616,11 +616,11 @@ def run_update_docs(pargs, test_report):
 
     if is_git_installed() is False:
         test_report.test_line("Skipping Update Docs because git is not installed")
-        status = yellow_text("Skipped because git not installed")
+        status = yellow_text("SKIPPED: git not installed")
         passed = True
     elif is_path_in_git(pypeit_dir) is False:
         test_report.test_line("Skipping Update Docs because PypeIt is not being run from git")
-        status = yellow_text("Skipped because PypeIt not in git")
+        status = yellow_text("SKIPPED: PypeIt not in git")
         passed = True
     else:
         pypeit_parent_dir = os.path.dirname(pypeit_dir)


### PR DESCRIPTION
I added a "docs" test type to the `pypeit_test` script that runs the `update_docs` script and checks its output for errors. It also checks to see if `PypeIt` is being run from git and will skip the test if it is not.

**Full success output:**

```
Test Summary
--------------------------------------------------------
--- PYPEIT UNIT TESTS PASSED  247 passed, 58 warnings in 248.39s (0:04:08) ---
--- PYPEIT DEVELOPMENT SUITE UNIT TESTS PASSED  133 passed, 170 warnings in 645.86s (0:10:45) ---
--- PYPEIT UPDATE DOCS PASSED Sphinx build successful.---
--- PYPEIT DEVELOPMENT SUITE PASSED 0/0 TESTS  ---
Testing Started at 2024-02-06T14:27:22.930569
Testing Completed at 2024-02-06T14:43:59.681371
Total Time: 0:16:36.750802
```

**Failure output:**

```
Test Summary
--------------------------------------------------------
--- PYPEIT UPDATE DOCS FAILED Sphinx build FAILED: 7 warnings found.---
--- PYPEIT DEVELOPMENT SUITE PASSED 0/0 TESTS  ---
Testing Started at 2024-02-12T13:44:38.454089
Testing Completed at 2024-02-12T13:46:27.228778
Total Time: 0:01:48.774689
```

**Skipped output:**

```
Test Summary
--------------------------------------------------------
--- PYPEIT UPDATE DOCS PASSED SKIPPED: PypeIt not in git---
--- PYPEIT DEVELOPMENT SUITE PASSED 0/0 TESTS  ---
Testing Started at 2024-02-12T13:48:11.964524
Testing Completed at 2024-02-12T13:48:11.970962
Total Time: 0:00:00.006438
```
