### PR TITLE
Run dev-suite from a package rather than directly from git

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -360,7 +360,7 @@ Finally, set the ``QT_QPA_PLATFORM`` environment variable to
 Running in Nautilus
 -------------------
 
-The dev-suite can be run in the `Nautilus cluster <https://ucsd-prp.gitlab.io/>`__.
+The dev-suite can be run in the `Nautilus cluster <https://docs.nationalresearchplatform.org/>`__.
 To generate the YAML for a dev-suite job, use ``gen_kube_devsuite``.  If needed,
 a specific branch of both the PypeIt repository and the Pypeit-development-suite
 repository can be chosen using ``-p`` and ``-d`` respectively.  These default to
@@ -385,6 +385,10 @@ follows:
 
 ``rclone`` can also be used access the Nautilus S3 storage. When
 configuring use ``https://s3-west.nrp-nautilus.io`` as the endpoint.
+
+The default job created by ``gen_kube_devsuite``  runs directly from git. However it can be changed to run
+by building a new PypeIt package and installing from that, simulating what a user would get when 
+installing from PyPi. This is enabled with the ``--from_wheel`` or ``-w`` option.
 
 ``gen_kube_devsuite`` has additional code for generating coverage
 information and the test priority list. If ``--coverage`` and
@@ -419,8 +423,8 @@ To monitor a test in Nautilus as it is running, the logs can be tailed:
 
 Additionally they can be monitored with the `Nautilus Grafana page <https://grafana.nrp-nautilus.io/?orgId=1>`__.
 
-By default ``gen_kube_devsuite`` creates a job using a default container with PypeIt 
-pre-installed. It also supports running with different python versions by
+By default ``gen_kube_devsuite`` creates a job using a the latest Python container 
+available on Docker Hub. It also supports running with different python versions by
 selecting a different container. For example:
 
 .. code-block:: console

--- a/nautilus/gen_kube_devsuite
+++ b/nautilus/gen_kube_devsuite
@@ -26,6 +26,7 @@ def parser(options=None):
     parser.add_argument('outfile', type=str, default=None, help='Name of the YAML outfile')
     parser.add_argument('-p', '--pypeit_branch', type=str, default='develop', help='Name of the PypeIt branch to test')
     parser.add_argument('-d', '--dev_branch', type=str, default='develop', help='Name of the PypeIt Dev-Suite branch to use')
+    parser.add_argument('-w', '--from_wheel', default=False, action='store_true', help='If set build a PypeIt wheel and install PypeIt from that. The default behavior is to install PypeIt directly from git.')
     parser.add_argument('--ncpu', type=int, default=8, help='Number of CPUs request')
     parser.add_argument('--ram', type=int, default=100, help='Amount of RAM to request (Gi)')
     parser.add_argument('--coverage', default=False, action="store_true", help="Collect code coverage data.")
@@ -72,16 +73,27 @@ def main():
     my_args = 'apt-get -y update; apt-get -y install git awscli build-essential qtbase5-dev rclone;'
     my_args += ' cd /tmp;'
     my_args += ' git clone https://github.com/pypeit/PypeIt.git; cd PypeIt;'
+    my_args += f' git checkout {pargs.pypeit_branch};' 
 
     # Install PypeIt
-    my_args += f' git checkout {pargs.pypeit_branch};' 
-    my_args += ' git pull --ff-only;'
-    my_args += ' pip install -e ".[dev,specutils]";'
-    # Telluric
-    my_args += ' cd pypeit/data/telluric/atm_grids;'
-    my_args += ' aws --endpoint $ENDPOINT_URL s3 cp s3://pypeit/telluric/atm_grids/TelFit_MaunaKea_3100_26100_R20000.fits /tmp/telluric/TelFit_MaunaKea_3100_26100_R20000.fits --no-progress;'
-    my_args += ' aws --endpoint $ENDPOINT_URL s3 cp s3://pypeit/telluric/atm_grids/TelFit_LasCampanas_3100_26100_R20000.fits /tmp/telluric/TelFit_LasCampanas_3100_26100_R20000.fits --no-progress;'
-    my_args += ' ln -s /tmp/telluric/* .;'
+    if pargs.from_wheel:
+        # Build a PypeIt wheel and install from it
+        my_args += ' pip install setuptools extension_helpers;'
+        my_args += ' python setup.py sdist bdist_wheel;'
+        my_args += ' whl_file=(dist/pypeit*.whl);'
+        my_args += ' pip install ${whl_file}[dev];'
+    else:
+        # Install directly from git
+        my_args += ' pip install -e ".[dev,specutils]";'
+
+        # Telluric
+        # These are not installed when running from a wheel so that the cache code to download
+        # the telluric data is tested.
+        my_args += ' cd pypeit/data/telluric/atm_grids;'
+        my_args += ' aws --endpoint $ENDPOINT_URL s3 cp s3://pypeit/telluric/atm_grids/TelFit_MaunaKea_3100_26100_R20000.fits /tmp/telluric/TelFit_MaunaKea_3100_26100_R20000.fits --no-progress;'
+        my_args += ' aws --endpoint $ENDPOINT_URL s3 cp s3://pypeit/telluric/atm_grids/TelFit_LasCampanas_3100_26100_R20000.fits /tmp/telluric/TelFit_LasCampanas_3100_26100_R20000.fits --no-progress;'
+        my_args += ' ln -s /tmp/telluric/* .;'
+    
     # Dev suite
     my_args += ' cd /tmp;'
     my_args += f' git clone --branch {pargs.dev_branch}  --depth 1 https://github.com/pypeit/PypeIt-development-suite.git;'
@@ -91,8 +103,10 @@ def main():
     my_args += ' echo Copying CALIBS from Google Drive...; rclone --config nautilus/rclone.conf copy gdrive:CALIBS/ CALIBS/;'
     # Raw Data
     my_args += ' echo Copying RAW_DATA from Google Drive...; rclone --config nautilus/rclone.conf copy gdrive:RAW_DATA/ RAW_DATA/;'
-    # Run the test and copy results back to s3
+    # Run the test 
     my_args += f' ./pypeit_test -t {pargs.ncpu} {" ".join(arguments)} -r pypeit.report -o /tmp/REDUX_OUT --csv performance.csv;'
+
+    #Copy results back to s3    
     my_args += f' aws --endpoint $ENDPOINT_URL s3 cp pypeit.report s3://pypeit/Reports/{pargs.name}.report;'
     my_args += f' aws --endpoint $ENDPOINT_URL s3 cp performance.csv s3://pypeit/Reports/{pargs.name}_performance.csv;'
     if pargs.coverage:

--- a/nautilus/gen_kube_devsuite
+++ b/nautilus/gen_kube_devsuite
@@ -84,7 +84,7 @@ def main():
         my_args += ' pip install ${whl_file}[dev];'
     else:
         # Install directly from git
-        my_args += ' pip install -e ".[dev,specutils]";'
+        my_args += ' pip install -e ".[dev]";'
 
         # Telluric
         # These are not installed when running from a wheel so that the cache code to download

--- a/nautilus/kube_dev_suite.yaml
+++ b/nautilus/kube_dev_suite.yaml
@@ -35,11 +35,11 @@ spec:
         resources:
           limits:
             cpu: '7'
-            ephemeral-storage: 300Gi
+            ephemeral-storage: 350Gi
             memory: 100Gi
           requests:
             cpu: '6'
-            ephemeral-storage: 250Gi
+            ephemeral-storage: 300Gi
             memory: 50Gi
         volumeMounts:
         - mountPath: /root/.aws/credentials


### PR DESCRIPTION
This PR adds the -w/--from_wheel option to gen_kube_devsuite, telling it to create Natuilus jobs that will build a new PypeIt package (aka wheel) from git, and then install from that package rather than installing directly from git. This simulates what the user would get when installing from PyPi. 

I also increased the ephemeral storage request because we were getting close to the max and I had seen a previous test run fail because it was exceeded.

In order to run successfully with the -w option, some fixes were needed in PypeIt. These have been included in the numpy_v2 branch in that repository. Therefore this PR should not be merged until after both the PyepIt numpy_v2 and PypeIt-development-suite numpy_v2 branches are merged.