### PR TITLE
Update gen_kube_devsuite yml to prevent devsuite pods from hanging 

### DIFF
--- a/nautilus/kube_dev_suite.yaml
+++ b/nautilus/kube_dev_suite.yaml
@@ -52,8 +52,6 @@ spec:
         - mountPath: /root/.config/service_account.json
           name: devsuite-rawdata
           subPath: credentials
-      nodeSelector:
-        nautilus.io/disktype: nvme
       restartPolicy: Never
       volumes:
       - name: prp-s3-credentials


### PR DESCRIPTION
Nautilus deprecated the disktype node label since all the nodes have SSDs now. This meant that the nodeSelector we had in our yml will cause the job to hang  forever with pods waiting in the PENDING state . 

I fixed this by removing the now unnecessary lines.