### PR TITLE
Deal with unstable HIRES failure

### DIFF
--- a/pypeit_files/keck_hires_j0100+2802_h204hr_red_c1_ech_0.75_xd_1.69_1x2.pypeit
+++ b/pypeit_files/keck_hires_j0100+2802_h204hr_red_c1_ech_0.75_xd_1.69_1x2.pypeit
@@ -4,6 +4,8 @@
 # User-defined execution parameters
 [rdx]
     spectrograph = keck_hires
+[baseprocess]
+    use_illumflat = False  # illum flat fielding seems unstable	and make this dataset to fail randomly
 
 # Setup
 setup read


### PR DESCRIPTION
This HIRES datasets has been ON/OFF failing for several months now. I do not know why, but it's related to the illumination flat of an order close to the edge of the detector. Therefore, I turn off illumination correction.

This is companion of PR https://github.com/pypeit/PypeIt/pull/1934, but not really related.