### PR TITLE
Tar up and copy to AWS the test logs for inspection

### DIFF
--- a/nautilus/gen_kube_devsuite
+++ b/nautilus/gen_kube_devsuite
@@ -122,9 +122,13 @@ def main():
     # Run the test 
     my_args += f' ./pypeit_test -t {pargs.ncpu} {" ".join(arguments)} -r pypeit.report -o /tmp/REDUX_OUT --csv performance.csv;'
 
+    # Tar up the logs
+    my_args += f' find /tmp/REDUX_OUT -name "*test*log" -print | tar cfz logtar.tar.gz -T -;'
+
     #Copy results back to s3    
     my_args += f' aws --endpoint $ENDPOINT_URL s3 cp pypeit.report s3://pypeit/Reports/{pargs.name}.report;'
     my_args += f' aws --endpoint $ENDPOINT_URL s3 cp performance.csv s3://pypeit/Reports/{pargs.name}_performance.csv;'
+    my_args += f' aws --endpoint $ENDPOINT_URL s3 cp logtar.tar.gz s3://pypeit/Logs/{pargs.name}.logs.tgz;'
     if pargs.coverage:
         my_args += f' aws --endpoint $ENDPOINT_URL s3 cp coverage.report s3://pypeit/Reports/{pargs.name}.coverage.report;'
     if pargs.priority_list:


### PR DESCRIPTION
As titled.

Allows for inspection of failed Nautilus DevSuite tests without the need to re-run the test locally.