### PR TITLE
Add slitmask ingestion test and update MMT/Binospec pypeit files

### DIFF
--- a/pypeit_files/mmt_binospec_longslit_g1000.pypeit
+++ b/pypeit_files/mmt_binospec_longslit_g1000.pypeit
@@ -1,5 +1,5 @@
-# Auto-generated PypeIt input file using PypeIt version: 1.11.1.dev448+g808467667
-# UTC 2023-02-28T07:13:48.906
+# Auto-generated PypeIt input file using PypeIt version: 1.18.2.dev657+g0c5e6c4d9
+# UTC 2026-02-03T21:53:49.983+00:00
 
 # User-defined execution parameters
 [rdx]
@@ -13,10 +13,10 @@ setup end
 
 # Data block 
 data read
- path .
-                     filename |                 frametype |                 ra |               dec |       target | dispname |  decker | binning |         mjd | airmass | exptime
-sci_img_2022.0327.064350.fits |                  arc,tilt | 159.77499999999998 | 43.10069444444444 | Feige34_1000 |    x1000 | default |     1 1 | 59665.27672 |  1.0374 |   300.0
-sci_img_2022.0327.065147.fits | pixelflat,illumflat,trace | 159.77499999999998 | 43.10069444444444 | Feige34_1000 |    x1000 | default |     1 1 | 59665.28482 |  1.0462 |    75.0
-sci_img_2022.0327.063501.fits |                  standard | 159.77499999999998 | 43.10069444444444 | Feige34_1000 |    x1000 | default |     1 1 | 59665.27392 |  1.0348 |    15.0
+ path ./Longslit_G1000
+                     filename |                 frametype |                 ra |               dec |       target | dispname |    decker | binning |         mjd | airmass | exptime | calib
+sci_img_2022.0327.064350.fits |                  arc,tilt | 159.77499999999998 | 43.10069444444444 | Feige34_1000 |    x1000 | Longslit1 |     1 1 | 59665.27672 |  1.0374 |   300.0 |     0
+sci_img_2022.0327.065147.fits | pixelflat,illumflat,trace | 159.77499999999998 | 43.10069444444444 | Feige34_1000 |    x1000 | Longslit1 |     1 1 | 59665.28482 |  1.0462 |    75.0 |     0
+sci_img_2022.0327.063501.fits |                  standard | 159.77499999999998 | 43.10069444444444 | Feige34_1000 |    x1000 | Longslit1 |     1 1 | 59665.27392 |  1.0348 |    15.0 |     0
 data end
 

--- a/pypeit_files/mmt_binospec_longslit_g600.pypeit
+++ b/pypeit_files/mmt_binospec_longslit_g600.pypeit
@@ -1,33 +1,24 @@
-# Auto-generated PypeIt file
-# Tue 11 Aug 2020 12:18:18
+# Auto-generated PypeIt input file using PypeIt version: 1.18.2.dev657+g0c5e6c4d9
+# UTC 2026-02-03T17:47:37.915+00:00
 
 # User-defined execution parameters
 [rdx]
-spectrograph = mmt_binospec
+    spectrograph = mmt_binospec
 
 # Setup
 setup read
- Setup A:
-   --:
-     binning: 1 1
-     dichroic: default
-     disperser:
-       angle: none
-       name: x600
-     slit:
-       decker: default
-       slitlen: none
-       slitwid: none
+Setup A:
+  dispname: x600
 setup end
 
-# Read in the data
+# Data block 
 data read
- path /Users/feige/Software/python3/PypeIt-development-suite/RAW_DATA/mmt_binospec/Longslit_G600
-|                      filename |                 frametype |         ra |         dec |    target | dispname |  decker | binning |         mjd | airmass | exptime |
-| sci_img_2018.0209.061629.fits |                  arc,tilt | 4.65756979 | 16.62106728 | Longslit1 |     x600 | default |     1 1 | 58158.25781 |   1.509 |   300.0 |
-| sci_img_2018.0209.061743.fits | pixelflat,illumflat,trace | 4.65756979 | 16.62106728 | Longslit1 |     x600 | default |     1 1 | 58158.26191 |  1.5476 |    20.0 |
-| sci_img_2018.0209.061852.fits | pixelflat,illumflat,trace | 4.65756979 | 16.62106728 | Longslit1 |     x600 | default |     1 1 | 58158.26269 |  1.5552 |    20.0 |
-| sci_img_2018.0209.062002.fits | pixelflat,illumflat,trace | 4.65756979 | 16.62106728 | Longslit1 |     x600 | default |     1 1 | 58158.26351 |  1.5634 |    20.0 |
-| sci_img_2018.0209.035515.fits |                   science | 4.65756979 | 16.62106728 | Longslit1 |     x600 | default |     1 1 | 58158.15046 |   1.056 |  1100.0 |
+ path ./Longslit_G600
+                     filename |                 frametype |         ra |         dec |    target | dispname |    decker | binning |         mjd | airmass | exptime | calib
+sci_img_2018.0209.061629.fits |                  arc,tilt | 4.65756979 | 16.62106728 | Longslit1 |     x600 | Longslit1 |     1 1 | 58158.25781 |   1.509 |   300.0 |     0
+sci_img_2018.0209.061743.fits | pixelflat,illumflat,trace | 4.65756979 | 16.62106728 | Longslit1 |     x600 | Longslit1 |     1 1 | 58158.26191 |  1.5476 |    20.0 |     0
+sci_img_2018.0209.061852.fits | pixelflat,illumflat,trace | 4.65756979 | 16.62106728 | Longslit1 |     x600 | Longslit1 |     1 1 | 58158.26269 |  1.5552 |    20.0 |     0
+sci_img_2018.0209.062002.fits | pixelflat,illumflat,trace | 4.65756979 | 16.62106728 | Longslit1 |     x600 | Longslit1 |     1 1 | 58158.26351 |  1.5634 |    20.0 |     0
+sci_img_2018.0209.035515.fits |                   science | 4.65756979 | 16.62106728 | Longslit1 |     x600 | Longslit1 |     1 1 | 58158.15046 |   1.056 |  1100.0 |     0
 data end
 

--- a/unit_tests/test_load_images.py
+++ b/unit_tests/test_load_images.py
@@ -186,3 +186,12 @@ def test_load_apf_levy():
     except:
         pytest.fail('APF Levy test data section failed: {0}'.format(ifile))
 
+
+def test_load_mmt_binospec():
+    ifile = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA','mmt_binospec',
+                         'Multislit_G270', 'BOSS1441_350.Science.6785.fits')
+    try:
+        data_img = grab_img('mmt_binospec', ifile)
+    except:
+        pytest.fail('MMT Binospec test data section failed: {0}'.format(ifile))
+

--- a/unit_tests/test_slitmask.py
+++ b/unit_tests/test_slitmask.py
@@ -1,0 +1,53 @@
+"""
+Simple tests that load files and parse the slit-mask design data.
+"""
+
+import os
+from pathlib import Path
+
+from IPython import embed
+import numpy as np
+
+from pypeit.spectrographs.util import load_spectrograph
+
+# TODO: Add additional tests for other spectrographs with slit-mask design data
+
+def test_get_slitmask_mmt_binospec():
+    ifile = (
+        Path(os.getenv('PYPEIT_DEV')).absolute() / 'RAW_DATA' / 'mmt_binospec' / 'Multislit_G270'
+        / 'BOSS1441_350.Science.6785.fits'
+    )
+    spec = load_spectrograph('mmt_binospec')
+    slits = spec.get_slitmask(ifile, det=1)
+
+    assert slits.nslits == 72, 'Incorrect number of slits'
+    assert np.array_equal(slits.slitid, np.arange(slits.nslits)+1), 'slit IDs are incorrect'
+
+    assert slits.corners.shape == (72, 4, 2), 'Corner shape is incorrect'
+
+
+    slits = spec.get_slitmask(ifile, det=2)
+
+    assert slits.nslits == 73, 'Incorrect number of slits'
+    assert np.array_equal(slits.slitid, np.arange(slits.nslits)+1), 'slit IDs are incorrect'
+
+    assert slits.corners.shape == (73, 4, 2), 'Corner shape is incorrect'
+
+    # Test that the slit mask code works for longslit data
+    ifile = (
+        Path(os.getenv('PYPEIT_DEV')).absolute() / 'RAW_DATA' / 'mmt_binospec' / 'Longslit_G600'
+        / 'sci_img_2018.0209.035515.fits'
+    )
+    slits = spec.get_slitmask(ifile, det=1)
+    assert slits.nslits == 1, 'Incorrect number of slits'
+
+    # Test that the slit mask code works for longslit data
+    ifile = (
+        Path(os.getenv('PYPEIT_DEV')).absolute() / 'RAW_DATA' / 'mmt_binospec' / 'Longslit_G1000'
+        / 'sci_img_2022.0327.063501.fits'
+    )
+    slits = spec.get_slitmask(ifile, det=1)
+    assert slits.nslits == 1, 'Incorrect number of slits'
+
+
+

--- a/unit_tests/test_slitmask.py
+++ b/unit_tests/test_slitmask.py
@@ -25,7 +25,6 @@ def test_get_slitmask_mmt_binospec():
 
     assert slits.corners.shape == (72, 4, 2), 'Corner shape is incorrect'
 
-
     slits = spec.get_slitmask(ifile, det=2)
 
     assert slits.nslits == 73, 'Incorrect number of slits'
@@ -48,6 +47,3 @@ def test_get_slitmask_mmt_binospec():
     )
     slits = spec.get_slitmask(ifile, det=1)
     assert slits.nslits == 1, 'Incorrect number of slits'
-
-
-


### PR DESCRIPTION
As titled, paired with https://github.com/pypeit/PypeIt/pull/2053.

I don't know why, but the previous pypeit files for the longslit data had set the `decker` to "default".  This was causing havoc with the new mask-design matching code (i.e., the code was not recognizing the data as longslit data and was trying to treat it as multislit data).  I updated the pypeit code so that it can ingest slitmask data for MMT/Binospec when there is only one slit, and I added new pypeit files in this PR that are exactly the same as what is produced by `pypeit_setup`.