### PR TITLE
Add LDT/RIMAS

### DIFF
--- a/pypeit_files/ldt_rimas_vph_vph300_hk.pypeit
+++ b/pypeit_files/ldt_rimas_vph_vph300_hk.pypeit
@@ -1,0 +1,34 @@
+# Auto-generated PypeIt input file using PypeIt version: 2.0.2.dev176+g8726d2694.d20260401
+# UTC 2026-04-15T20:50:46.075+00:00
+
+# User-defined execution parameters
+[rdx]
+    spectrograph = ldt_rimas_vph
+
+# Setup
+setup read
+Setup 300HK12l:
+  arm: HK
+  decker: 1.2'' long
+  dispname: Vph300
+setup end
+
+# Data block 
+data read
+ path RAWDIR
+                   filename |                 frametype |                 ra |                dec |    target | dispname |     decker | binning |                mjd |         airmass | exptime | arm | slitwid | lampstat01 | filter1 | dithpat | dithpos | calib | comb_id | bkg_id
+20260305.rimas.0090.HK.fits |          arc,science,tilt |  76.37620833333332 |  52.82658333333334 |  G191-B2B |   Vph300 | 1.2'' long |     1,1 |  61104.15109470735 |  1.127862339736 |  120.12 |  HK |     1.2 |        off |    open |    ABBA |       A |     0 |       1 |      2
+20260305.rimas.0091.HK.fits |          arc,science,tilt |  76.37608333333333 |  52.82655555555556 |  G191-B2B |   Vph300 | 1.2'' long |     1,1 |  61104.15274768438 | 1.1312480823158 |  120.12 |  HK |     1.2 |        off |    open |    ABBA |       B |     0 |       2 |      1
+20260305.rimas.0092.HK.fits |          arc,science,tilt |  76.37620833333332 |  52.82377777777778 |  G191-B2B |   Vph300 | 1.2'' long |     1,1 |  61104.15440055214 | 1.1344665152388 |  120.12 |  HK |     1.2 |        off |    open |    ABBA |       B |     0 |       3 |      4
+20260305.rimas.0093.HK.fits |          arc,science,tilt |  76.37620833333332 |  52.82380555555556 |  G191-B2B |   Vph300 | 1.2'' long |     1,1 |  61104.15605343813 | 1.1370478282663 |  120.12 |  HK |     1.2 |        off |    open |    ABBA |       A |     0 |       4 |      3
+20260306.rimas.0006.HK.fits |                      dark |                0.0 |                0.0 |      null |   Vph300 | 1.2'' long |     1,1 |   61105.7330886759 |             0.0 |  120.12 |  HK |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260306.rimas.0008.HK.fits |                      dark |                0.0 |                0.0 |      null |   Vph300 | 1.2'' long |     1,1 | 61105.736362018804 |             0.0 |  120.12 |  HK |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260306.rimas.0010.HK.fits |                      dark |                0.0 |                0.0 |      null |   Vph300 | 1.2'' long |     1,1 | 61105.739635376565 |             0.0 |  120.12 |  HK |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260305.rimas.0026.HK.fits |              lampoffflats | 114.79933333333332 | 10.882238888888889 | dome dark |   Vph300 | 1.2'' long |     1,1 |  61104.05372127251 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0027.HK.fits |              lampoffflats | 114.87870833333332 | 10.882425000000001 | dome dark |   Vph300 | 1.2'' long |     1,1 |   61104.0539187306 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0028.HK.fits |              lampoffflats | 114.94558333333332 | 10.882580555555556 | dome dark |   Vph300 | 1.2'' long |     1,1 | 61104.054116183346 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0011.HK.fits | pixelflat,illumflat,trace | 111.41887499999999 | 10.874152777777779 | dome flat |   Vph300 | 1.2'' long |     1,1 |  61104.04439927659 | 1.4611488954213 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0012.HK.fits | pixelflat,illumflat,trace | 111.66958333333332 | 10.874752777777779 | dome flat |   Vph300 | 1.2'' long |     1,1 |  61104.04505091693 | 1.4611488954213 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0013.HK.fits | pixelflat,illumflat,trace | 111.73645833333332 | 10.874913888888889 | dome flat |   Vph300 | 1.2'' long |     1,1 |  61104.04524836759 | 1.4611488954213 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+data end
+

--- a/pypeit_files/ldt_rimas_vph_vph300_yj.pypeit
+++ b/pypeit_files/ldt_rimas_vph_vph300_yj.pypeit
@@ -1,0 +1,34 @@
+# Auto-generated PypeIt input file using PypeIt version: 2.0.2.dev176+g8726d2694.d20260401
+# UTC 2026-04-15T22:51:41.789+00:00
+
+# User-defined execution parameters
+[rdx]
+    spectrograph = ldt_rimas_vph
+
+# Setup
+setup read
+Setup 300YJ12l:
+  arm: YJ
+  decker: 1.2'' long
+  dispname: Vph300
+setup end
+
+# Data block 
+data read
+ path RAWDIR
+                   filename |                 frametype |                 ra |                dec |    target | dispname |     decker | binning |                mjd |         airmass | exptime | arm | slitwid | lampstat01 | filter1 | dithpat | dithpos | calib | comb_id | bkg_id
+20260305.rimas.0090.YJ.fits |          arc,science,tilt |  76.37620833333332 |  52.82658333333334 |  G191-B2B |   Vph300 | 1.2'' long |     1,1 |  61104.15109470735 |  1.127862339736 |  120.12 |  YJ |     1.2 |        off |    open |    ABBA |       A |     0 |       1 |      2
+20260305.rimas.0091.YJ.fits |          arc,science,tilt |  76.37608333333333 |  52.82655555555556 |  G191-B2B |   Vph300 | 1.2'' long |     1,1 |  61104.15274768438 | 1.1312480823158 |  120.12 |  YJ |     1.2 |        off |    open |    ABBA |       B |     0 |       2 |      1
+20260305.rimas.0092.YJ.fits |          arc,science,tilt |  76.37620833333332 |  52.82377777777778 |  G191-B2B |   Vph300 | 1.2'' long |     1,1 |  61104.15440055214 | 1.1344665152388 |  120.12 |  YJ |     1.2 |        off |    open |    ABBA |       B |     0 |       3 |      4
+20260305.rimas.0093.YJ.fits |          arc,science,tilt |  76.37620833333332 |  52.82380555555556 |  G191-B2B |   Vph300 | 1.2'' long |     1,1 |  61104.15605343813 | 1.1370478282663 |  120.12 |  YJ |     1.2 |        off |    open |    ABBA |       A |     0 |       4 |      3
+20260306.rimas.0006.YJ.fits |                      dark |                0.0 |                0.0 |      null |   Vph300 | 1.2'' long |     1,1 |   61105.7330886759 |             0.0 |  120.12 |  YJ |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260306.rimas.0008.YJ.fits |                      dark |                0.0 |                0.0 |      null |   Vph300 | 1.2'' long |     1,1 | 61105.736362018804 |             0.0 |  120.12 |  YJ |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260306.rimas.0010.YJ.fits |                      dark |                0.0 |                0.0 |      null |   Vph300 | 1.2'' long |     1,1 | 61105.739635376565 |             0.0 |  120.12 |  YJ |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260305.rimas.0036.YJ.fits |              lampoffflats | 115.89412499999999 | 10.884797222222222 | dome dark |   Vph300 | 1.2'' long |     1,1 | 61104.055955325406 | 1.4611465635881 |   60.06 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0038.YJ.fits |              lampoffflats |         116.554375 | 10.886330555555555 | dome dark |   Vph300 | 1.2'' long |     1,1 |  61104.05780427523 | 1.4611465635881 |   60.06 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0040.YJ.fits |              lampoffflats | 117.15195833333331 | 10.887708333333332 | dome dark |   Vph300 | 1.2'' long |     1,1 |    61104.059653223 | 1.4611465635881 |   60.06 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0021.YJ.fits | pixelflat,illumflat,trace | 113.12374999999999 | 10.878227777777779 | dome flat |   Vph300 | 1.2'' long |     1,1 |  61104.04825542088 | 1.4611488954213 |   60.06 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0022.YJ.fits | pixelflat,illumflat,trace | 113.41208333333331 | 10.878911111111112 | dome flat |   Vph300 | 1.2'' long |     1,1 |   61104.0491150567 | 1.4611488954213 |   60.06 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0023.YJ.fits | pixelflat,illumflat,trace | 113.72966666666665 | 10.879663888888889 | dome flat |   Vph300 | 1.2'' long |     1,1 |  61104.04997467684 | 1.4611488954213 |   60.06 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+data end
+

--- a/pypeit_files/ldt_rimas_vph_vph30_hk.pypeit
+++ b/pypeit_files/ldt_rimas_vph_vph30_hk.pypeit
@@ -1,0 +1,34 @@
+# Auto-generated PypeIt input file using PypeIt version: 2.0.2.dev176+g8726d2694.d20260401
+# UTC 2026-04-15T22:55:43.666+00:00
+
+# User-defined execution parameters
+[rdx]
+    spectrograph = ldt_rimas_vph
+
+# Setup
+setup read
+Setup 30HK12l:
+  arm: HK
+  decker: 1.2'' long
+  dispname: Vph30
+setup end
+
+# Data block 
+data read
+ path RAWDIR
+                   filename |                 frametype |                 ra |                dec |    target | dispname |     decker | binning |                mjd |         airmass | exptime | arm | slitwid | lampstat01 | filter1 | dithpat | dithpos | calib | comb_id | bkg_id
+20260305.rimas.0082.HK.fits |          arc,science,tilt |  76.37624999999998 |  52.82655555555556 |  G191-B2B |    Vph30 | 1.2'' long |     1,1 | 61104.138676508286 | 1.1044856699032 |   60.06 |  HK |     1.2 |        off |    open |    ABBA |       A |     0 |       1 |      2
+20260305.rimas.0083.HK.fits |          arc,science,tilt |  76.37624999999998 |  52.82655555555556 |  G191-B2B |    Vph30 | 1.2'' long |     1,1 |  61104.13960108859 | 1.1057380057008 |   60.06 |  HK |     1.2 |        off |    open |    ABBA |       B |     0 |       2 |      1
+20260305.rimas.0084.HK.fits |          arc,science,tilt |  76.37624999999998 |  52.82372222222222 |  G191-B2B |    Vph30 | 1.2'' long |     1,1 | 61104.140493114435 | 1.1071814005167 |   60.06 |  HK |     1.2 |        off |    open |    ABBA |       B |     0 |       3 |      4
+20260305.rimas.0085.HK.fits |          arc,science,tilt |  76.37624999999998 |  52.82380555555556 |  G191-B2B |    Vph30 | 1.2'' long |     1,1 |  61104.14138514478 |  1.108415599486 |   60.06 |  HK |     1.2 |        off |    open |    ABBA |       A |     0 |       4 |      3
+20260306.rimas.0016.HK.fits |                      dark |                0.0 |                0.0 |      null |    Vph30 | 1.2'' long |     1,1 | 61105.750298907675 |             0.0 |   60.06 |  HK |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260306.rimas.0018.HK.fits |                      dark |                0.0 |                0.0 |      null |    Vph30 | 1.2'' long |     1,1 | 61105.752147864085 |             0.0 |   60.06 |  HK |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260306.rimas.0019.HK.fits |                      dark |                0.0 |                0.0 |      null |    Vph30 | 1.2'' long |     1,1 |  61105.75300750148 |             0.0 |   60.06 |  HK |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260305.rimas.0060.HK.fits |              lampoffflats | 122.47162499999999 | 10.899666666666667 | dome dark |    Vph30 | 1.2'' long |     1,1 |  61104.07496857548 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0061.HK.fits |              lampoffflats | 122.55104166666663 | 10.899841666666665 | dome dark |    Vph30 | 1.2'' long |     1,1 |  61104.07516600866 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0062.HK.fits |              lampoffflats | 122.61787499999997 |               10.9 | dome dark |    Vph30 | 1.2'' long |     1,1 |  61104.07536345596 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0045.HK.fits | pixelflat,illumflat,trace | 120.26516666666667 | 10.894780555555554 | dome flat |    Vph30 | 1.2'' long |     1,1 |  61104.06886436774 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0046.HK.fits | pixelflat,illumflat,trace | 120.34458333333332 | 10.894958333333333 | dome flat |    Vph30 | 1.2'' long |     1,1 | 61104.069061805385 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0047.HK.fits | pixelflat,illumflat,trace | 120.41141666666668 | 10.895108333333333 | dome flat |    Vph30 | 1.2'' long |     1,1 |  61104.06925926757 | 1.4611465635881 |    5.72 |  HK |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+data end
+

--- a/pypeit_files/ldt_rimas_vph_vph30_yj.pypeit
+++ b/pypeit_files/ldt_rimas_vph_vph30_yj.pypeit
@@ -1,0 +1,34 @@
+# Auto-generated PypeIt input file using PypeIt version: 2.0.2.dev176+g8726d2694.d20260401
+# UTC 2026-04-15T22:57:57.360+00:00
+
+# User-defined execution parameters
+[rdx]
+    spectrograph = ldt_rimas_vph
+
+# Setup
+setup read
+Setup 30YJ12l:
+  arm: YJ
+  decker: 1.2'' long
+  dispname: Vph30
+setup end
+
+# Data block 
+data read
+ path RAWDIR
+                   filename |                 frametype |                 ra |                dec |    target | dispname |     decker | binning |                mjd |         airmass | exptime | arm | slitwid | lampstat01 | filter1 | dithpat | dithpos | calib | comb_id | bkg_id
+20260305.rimas.0082.YJ.fits |          arc,science,tilt |  76.37624999999998 |  52.82655555555556 |  G191-B2B |    Vph30 | 1.2'' long |     1,1 | 61104.138676508286 | 1.1044856699032 |   60.06 |  YJ |     1.2 |        off |    open |    ABBA |       A |     0 |       1 |      2
+20260305.rimas.0083.YJ.fits |          arc,science,tilt |  76.37629166666666 |  52.82655555555556 |  G191-B2B |    Vph30 | 1.2'' long |     1,1 |  61104.13960108859 | 1.1055967562294 |   60.06 |  YJ |     1.2 |        off |    open |    ABBA |       B |     0 |       2 |      1
+20260305.rimas.0084.YJ.fits |          arc,science,tilt |  76.37620833333332 |  52.82658333333334 |  G191-B2B |    Vph30 | 1.2'' long |     1,1 | 61104.140493114435 | 1.1070979643116 |   60.06 |  YJ |     1.2 |        off |    open |    ABBA |       B |     0 |       3 |      4
+20260305.rimas.0085.YJ.fits |          arc,science,tilt |  76.37624999999998 |  52.82380555555556 |  G191-B2B |    Vph30 | 1.2'' long |     1,1 |  61104.14138514478 |  1.108415599486 |   60.06 |  YJ |     1.2 |        off |    open |    ABBA |       A |     0 |       4 |      3
+20260306.rimas.0016.YJ.fits |                      dark |                0.0 |                0.0 |      null |    Vph30 | 1.2'' long |     1,1 | 61105.750298907675 |             0.0 |   60.06 |  YJ |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260306.rimas.0018.YJ.fits |                      dark |                0.0 |                0.0 |      null |    Vph30 | 1.2'' long |     1,1 | 61105.752147864085 |             0.0 |   60.06 |  YJ |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260306.rimas.0019.YJ.fits |                      dark |                0.0 |                0.0 |      null |    Vph30 | 1.2'' long |     1,1 |  61105.75300750148 |             0.0 |   60.06 |  YJ |     1.2 |        off |   blank |    None |    None |     0 |      -1 |     -1
+20260305.rimas.0070.YJ.fits |              lampoffflats | 123.35341666666666 |  10.90163888888889 | dome dark |    Vph30 | 1.2'' long |     1,1 | 61104.077072846885 | 1.4611465635881 |    28.6 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0071.YJ.fits |              lampoffflats | 123.52895833333329 | 10.902019444444445 | dome dark |    Vph30 | 1.2'' long |     1,1 | 61104.077535592376 | 1.4611465635881 |    28.6 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0072.YJ.fits |              lampoffflats | 123.68358333333332 | 10.902352777777779 | dome dark |    Vph30 | 1.2'' long |     1,1 |  61104.07799810046 | 1.4611465635881 |    28.6 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0055.YJ.fits | pixelflat,illumflat,trace | 121.21795833333331 | 10.896905555555556 | dome flat |    Vph30 | 1.2'' long |     1,1 |  61104.07126061942 | 1.4611465635881 |    28.6 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0056.YJ.fits | pixelflat,illumflat,trace |          121.59825 | 10.897747222222222 | dome flat |    Vph30 | 1.2'' long |     1,1 | 61104.072209836064 | 1.4611465635881 |    28.6 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+20260305.rimas.0057.YJ.fits | pixelflat,illumflat,trace | 121.75704166666667 | 10.898097222222221 | dome flat |    Vph30 | 1.2'' long |     1,1 | 61104.072673367176 | 1.4611465635881 |    28.6 |  YJ |     1.2 |        off |    open |    None |    None |   all |      -1 |     -1
+data end
+

--- a/test_scripts/setups.py
+++ b/test_scripts/setups.py
@@ -204,6 +204,12 @@ all_setups = {
         'DV8',
         'DV9',
     ],
+    'ldt_rimas_vph': [
+        'Vph30_YJ',
+        'Vph30_HK',
+        'Vph300_YJ',
+        'Vph300_HK',
+    ],
     'magellan_fire': [
         'FIRE_Echelle',
         'FIRE_Long',


### PR DESCRIPTION
DevSuite companion to https://github.com/pypeit/PypeIt/pull/2070.  Adds testing of basic reduction for the LDT/RIMAS spectrograph.

Will mark this PR for review when the main repo PR is ready.