### PR TITLE
Increase the tolerance for one of the CoAdd2d VET tests

### DIFF
--- a/vet_tests/test_coadd2d.py
+++ b/vet_tests/test_coadd2d.py
@@ -131,7 +131,7 @@ def test_offsets_with_user_obj_ids(redux_out):
     coadd = coadd2d.CoAdd2D.get_instance(spec2d_files, spectrograph, par)
 
     # Check the offsets
-    assert np.allclose(coadd.offsets, [0.0, 1.29, 3.91], atol=0.02), 'Wrong offsets'
+    assert np.allclose(coadd.offsets, [0.0, 1.29, 3.91], atol=0.1), 'Wrong offsets'
 
     # Check that, if no `user_obj_ids` are provided, other bright sources are detected
     par['coadd2d']['user_obj_ids'] = None


### PR DESCRIPTION
Per the discussion in https://github.com/pypeit/PypeIt/issues/2161, increase the tolerance of this particular VET test to allow for subtle changes in the processing of frames introduced throughout the PypeIt run to wiggle the traces up to 0.1 pix (rather than the previous 0.01 pix limit).  This should allow the VET test to pass, while still catching major issues with the CoAdd2d offset calculation.