### PR TITLE
MMIRS: regenerate long-slit setups and add a MOS test

### DIFF
--- a/pypeit_files/mmt_mmirs_h3000_h.pypeit
+++ b/pypeit_files/mmt_mmirs_h3000_h.pypeit
@@ -1,0 +1,34 @@
+# Auto-generated PypeIt file (regenerated for the geometry-driven A-B nod
+# pairing and the derived dither columns)
+
+# User-defined execution parameters
+[rdx]
+    spectrograph = mmt_mmirs
+[reduce]
+    [[findobj]]
+        maxnumber_sci = 1
+        maxnumber_std = 1
+
+# Setup
+setup read
+Setup A:
+  decker: 5pixel-long
+  dichroic: H
+  dispname: H3000
+setup end
+
+# Data block
+# The two science frames are a real ~10" along-slit nod (WNTR25gkqzi) and are
+# auto-paired A/B by get_comb_group.  This is the first post-2019 sexagesimal-
+# header MMIRS set in the dev suite, so it exercises deriving the dither offset
+# from the newer header format (see mmt_mmirs.compound_meta).  The single dark
+# is exposure-matched to the science frames for the ramp read-noise calibration.
+data read
+ path /Users/tim/MMT/PypeIt-development-suite/RAW_DATA/mmt_mmirs/H3000_H
+                                     filename |                 frametype |                ra |                 dec |                     target | dispname |      decker | binning |               mjd | airmass | exptime | dichroic | dithpat | dithpos |            dithoff | frameno | calib
+WNTR25gkqzi_H3000_Followup_longslit.3402.fits |          arc,science,tilt | 85.38541666666666 |  -2.292569444444444 | WNTR25gkqzi_H3000_Followup |    H3000 | 5pixel-long |     1,1 |       61126.15375 |   1.673 | 181.459 |        H |      BA |       B | -34.57644579741334 |    3402 |     0
+WNTR25gkqzi_H3000_Followup_longslit.3403.fits |          arc,science,tilt |         85.388125 | -2.2920138888888886 | WNTR25gkqzi_H3000_Followup |    H3000 | 5pixel-long |     1,1 |  61126.1559837963 |   1.696 | 181.459 |        H |      BA |       A | -24.63118811750212 |    3403 |     0
+                               dark.3745.fits |                      dark |               0.0 |                 0.0 |                       Dark |     open |        dark |     1,1 | 61126.58231481481 |     1.0 | 181.459 |     dark |    None |    None |                0.0 |    3745 |     0
+                               flat.3328.fits | pixelflat,illumflat,trace |               0.0 |                 0.0 |                       flat |    H3000 | 5pixel-long |     1,1 |     61125.9665625 |     1.0 |   4.426 |        H |    None |    None |                0.0 |    3328 |     0
+                               flat.3329.fits | pixelflat,illumflat,trace |               0.0 |                 0.0 |                       flat |    H3000 | 5pixel-long |     1,1 | 61125.96668981481 |     1.0 |   4.426 |        H |    None |    None |                0.0 |    3329 |     0
+data end

--- a/pypeit_files/mmt_mmirs_hk_hk3.pypeit
+++ b/pypeit_files/mmt_mmirs_hk_hk3.pypeit
@@ -1,0 +1,35 @@
+# Auto-generated PypeIt file (regenerated for the geometry-driven A-B nod
+# pairing and the derived dither columns)
+
+# User-defined execution parameters
+[rdx]
+    spectrograph = mmt_mmirs
+[reduce]
+    [[findobj]]
+        maxnumber_sci = 1
+        maxnumber_std = 1
+
+# Setup
+setup read
+Setup A:
+  decker: 5pixel-long
+  dichroic: HK3
+  dispname: HK
+setup end
+
+# Data block
+# The two science frames are a real ~30" along-slit nod (the supernova
+# SN2026ejy) and are auto-paired A/B by get_comb_group.  At 181s these frames
+# are long enough to double as the OH-airglow wavelength arc, and their post-2019
+# sexagesimal headers exercise deriving the dither offset from the newer format.
+# The single dark is exposure-matched to the science frames for the ramp
+# read-noise calibration.
+data read
+ path /Users/tim/MMT/PypeIt-development-suite/RAW_DATA/mmt_mmirs/HK_HK3
+                       filename |                 frametype |                 ra |                dec |       target | dispname |      decker | binning |               mjd | airmass | exptime | dichroic | dithpat | dithpos |             dithoff | frameno | calib
+SN2026ejy_HK_longslit.0037.fits |          arc,science,tilt | 242.50170833333334 | 0.7044499999999999 | SN2026ejy_HK |       HK | 5pixel-long |     1,1 |  61278.1766087963 |   1.625 | 181.459 |      HK3 |      AB |       A |  -4.605149951465026 |      37 |     0
+SN2026ejy_HK_longslit.0038.fits |          arc,science,tilt | 242.50166666666664 | 0.6961166666666667 | SN2026ejy_HK |       HK | 5pixel-long |     1,1 | 61278.17886574074 |   1.649 | 181.459 |      HK3 |      AB |       B | -34.605415895546486 |      38 |     0
+                 dark.0318.fits |                      dark |                0.0 |                0.0 |         Dark |     open |        dark |     1,1 | 61278.54136574074 |     1.0 | 181.459 |     dark |    None |    None |                 0.0 |     318 |     0
+                 flat.0366.fits | pixelflat,illumflat,trace |                0.0 |                0.0 |         flat |       HK | 5pixel-long |     1,1 | 61278.59916666667 |     1.0 |   4.426 |      HK3 |    None |    None |                 0.0 |     366 |     0
+                 flat.0367.fits | pixelflat,illumflat,trace |                0.0 |                0.0 |         flat |       HK | 5pixel-long |     1,1 | 61278.59931712963 |     1.0 |   4.426 |      HK3 |    None |    None |                 0.0 |     367 |     0
+data end

--- a/pypeit_files/mmt_mmirs_hk_zj.pypeit
+++ b/pypeit_files/mmt_mmirs_hk_zj.pypeit
@@ -1,5 +1,5 @@
-# Auto-generated PypeIt file
-# Tue 11 Aug 2020 12:21:54
+# Auto-generated PypeIt file (regenerated for the geometry-driven A-B nod
+# pairing and the derived dither columns)
 
 # User-defined execution parameters
 [rdx]
@@ -11,27 +11,22 @@
 
 # Setup
 setup read
- Setup A:
-   --:
-     binning: 1,1
-     dichroic: zJ
-     disperser:
-       angle: none
-       name: HK
-     slit:
-       decker: 5pixel-long
-       slitlen: none
-       slitwid: none
+Setup A:
+  decker: 5pixel-long
+  dichroic: zJ
+  dispname: HK
 setup end
 
-# Read in the data
+# Data block
+# The single science frame is reduced as a stare (no nod partner), while the
+# two standard-star frames are a real ~4" along-slit nod and are auto-paired
+# A/B by get_comb_group.
 data read
- path /Users/feige/Software/python3/PypeIt-development-suite/RAW_DATA/mmt_mmirs/HK_zJ
-|                           filename |                 frametype |          ra |         dec |          target | dispname |      decker | binning |                mjd | airmass | exptime | dichroic | calib |
-| J1758_2933-dire_longslit.6672.fits |          arc,science,tilt | 17.97245556 | 29.57148444 | J1758_2933-dire |       HK | 5pixel-long |     1,1 |  58302.38355324074 |   1.196 | 601.914 |       zJ |     0 |
-|                     flat.6675.fits | pixelflat,illumflat,trace | 17.97245556 | 29.57148444 | J1758_2933-dire |       HK | 5pixel-long |     1,1 | 58302.392488425925 |   1.236 |   4.426 |       zJ |     0 |
-|                     flat.6676.fits | pixelflat,illumflat,trace | 17.97245556 | 29.57148444 | J1758_2933-dire |       HK | 5pixel-long |     1,1 |  58302.39268518519 |   1.236 |   4.426 |       zJ |     0 |
-|        HIP92486_longslit.6680.fits |                  standard | 18.84954362 | 10.31210833 |        HIP92486 |       HK | 5pixel-long |     1,1 |  58302.39837962963 |   1.231 |  22.129 |       zJ |     0 |
-|        HIP92486_longslit.6681.fits |                  standard | 18.84954307 | 10.31321942 |        HIP92486 |       HK | 5pixel-long |     1,1 |  58302.39880787037 |   1.233 |  22.129 |       zJ |     0 |
+ path /Users/tim/MMT/PypeIt-development-suite/RAW_DATA/mmt_mmirs/HK_zJ
+                          filename |                 frametype |          ra |         dec |          target | dispname |      decker | binning |                mjd | airmass | exptime | dichroic | dithpat | dithpos |             dithoff | frameno | calib
+J1758_2933-dire_longslit.6672.fits |          arc,science,tilt | 17.97245556 | 29.57148444 | J1758_2933-dire |       HK | 5pixel-long |     1,1 |  58302.38355324074 |   1.196 | 601.914 |       zJ |    None |    None | -34.608203878124336 |    6672 |     0
+                    flat.6675.fits | pixelflat,illumflat,trace | 17.97245556 | 29.57148444 | J1758_2933-dire |       HK | 5pixel-long |     1,1 | 58302.392488425925 |   1.236 |   4.426 |       zJ |    None |    None | -34.608203878124336 |    6675 |     0
+                    flat.6676.fits | pixelflat,illumflat,trace | 17.97245556 | 29.57148444 | J1758_2933-dire |       HK | 5pixel-long |     1,1 |  58302.39268518519 |   1.236 |   4.426 |       zJ |    None |    None | -34.608203878124336 |    6676 |     0
+       HIP92486_longslit.6680.fits |                  standard | 18.84954362 | 10.31210833 |        HIP92486 |       HK | 5pixel-long |     1,1 |  58302.39837962963 |   1.231 |  22.129 |       zJ |      AB |       A |  -34.60733339231986 |    6680 |     0
+       HIP92486_longslit.6681.fits |                  standard | 18.84954307 | 10.31321942 |        HIP92486 |       HK | 5pixel-long |     1,1 |  58302.39880787037 |   1.233 |  22.129 |       zJ |      AB |       B |  -38.60735917926088 |    6681 |     0
 data end
-

--- a/pypeit_files/mmt_mmirs_j_zj.pypeit
+++ b/pypeit_files/mmt_mmirs_j_zj.pypeit
@@ -1,35 +1,30 @@
-# Auto-generated PypeIt file
-# Tue 11 Aug 2020 12:23:11
+# Auto-generated PypeIt file (regenerated for the geometry-driven A-B nod
+# pairing and the derived dither columns)
 
 # User-defined execution parameters
 [rdx]
-spectrograph = mmt_mmirs
+    spectrograph = mmt_mmirs
 [reduce]
     [[findobj]]
         snr_thresh = 50.
 
 # Setup
 setup read
- Setup A:
-   --:
-     binning: 1,1
-     dichroic: zJ
-     disperser:
-       angle: none
-       name: J
-     slit:
-       decker: 4pixel-long
-       slitlen: none
-       slitwid: none
+Setup A:
+  decker: 4pixel-long
+  dichroic: zJ
+  dispname: J
 setup end
 
-# Read in the data
+# Data block
+# comb_id/bkg_id are omitted on purpose: the two science frames are a real
+# ~4" along-slit nod, so get_comb_group auto-pairs them as A/B (comb 1,2 /
+# bkg 2,1).  This exercises the geometry-driven nod pairing.
 data read
- path /Users/feige/Software/python3/PypeIt-development-suite/RAW_DATA/mmt_mmirs/J_zJ
-|                          filename |                 frametype |          ra |         dec |         target | dispname |      decker | binning |                mjd | airmass | exptime | dichroic | calib | comb_id | bkg_id |
-| PAAlignJ134208_longslit.5475.fits |          arc,science,tilt | 13.70209353 |  9.47417222 | PAAlignJ134208 |        J | 4pixel-long |     1,1 | 57852.275289351855 |   1.142 | 300.957 |       zJ |     0 |       1 |      2 |
-| PAAlignJ134208_longslit.5476.fits |          arc,science,tilt | 13.70205124 |   9.4732542 | PAAlignJ134208 |        J | 4pixel-long |     1,1 | 57852.279016203705 |   1.134 | 300.957 |       zJ |     0 |       2 |      1 |
-|                    flat.5494.fits | pixelflat,illumflat,trace | 11.63234099 | 15.76900833 |           flat |        J | 4pixel-long |     1,1 |  57852.32210648148 |   1.157 |  10.327 |       zJ |     0 |      -1 |     -1 |
-|                    flat.5495.fits | pixelflat,illumflat,trace | 11.63234099 | 15.76900833 |           flat |        J | 4pixel-long |     1,1 |  57852.32239583333 |   1.157 |  10.327 |       zJ |     0 |      -1 |     -1 |
+ path /Users/tim/MMT/PypeIt-development-suite/RAW_DATA/mmt_mmirs/J_zJ
+                         filename |                 frametype |          ra |         dec |         target | dispname |      decker | binning |                mjd | airmass | exptime | dichroic | dithpat | dithpos |             dithoff | frameno | calib
+PAAlignJ134208_longslit.5475.fits |          arc,science,tilt | 13.70209353 |  9.47417222 | PAAlignJ134208 |        J | 4pixel-long |     1,1 | 57852.275289351855 |   1.142 | 300.957 |       zJ |      AB |       A | -34.602191668614616 |    5475 |     0
+PAAlignJ134208_longslit.5476.fits |          arc,science,tilt | 13.70205124 |   9.4732542 | PAAlignJ134208 |        J | 4pixel-long |     1,1 | 57852.279016203705 |   1.134 | 300.957 |       zJ |      AB |       B |  -38.60172052904397 |    5476 |     0
+                   flat.5494.fits | pixelflat,illumflat,trace | 11.63234099 | 15.76900833 |           flat |        J | 4pixel-long |     1,1 |  57852.32210648148 |   1.157 |  10.327 |       zJ |    None |    None |  -34.60059405279803 |    5494 |     0
+                   flat.5495.fits | pixelflat,illumflat,trace | 11.63234099 | 15.76900833 |           flat |        J | 4pixel-long |     1,1 |  57852.32239583333 |   1.157 |  10.327 |       zJ |    None |    None |  -34.60059405279803 |    5495 |     0
 data end
-

--- a/pypeit_files/mmt_mmirs_k_k.pypeit
+++ b/pypeit_files/mmt_mmirs_k_k.pypeit
@@ -1,32 +1,27 @@
-# Auto-generated PypeIt file
-# Tue 11 Aug 2020 12:23:57
+# Auto-generated PypeIt file (regenerated for the derived dither columns)
 
 # User-defined execution parameters
 [rdx]
-spectrograph = mmt_mmirs
+    spectrograph = mmt_mmirs
 
 # Setup
 setup read
- Setup A:
-   --:
-     binning: 1,1
-     dichroic: Kspec
-     disperser:
-       angle: none
-       name: K3000
-     slit:
-       decker: 4pixel-long
-       slitlen: none
-       slitwid: none
+Setup A:
+  decker: 4pixel-long
+  dichroic: Kspec
+  dispname: K3000
 setup end
 
-# Read in the data
+# Data block
+# The two science frames share a pointing (a stare, not an along-slit nod), so
+# get_comb_group would leave them unpaired.  comb_id/bkg_id are set explicitly
+# to keep the historical A-B reduction; supplying them also verifies that the
+# geometry-driven pairing is skipped when the user pins the groups.
 data read
- path /Users/feige/Software/python3/PypeIt-development-suite/RAW_DATA/mmt_mmirs/K_K
-|                        filename |                 frametype |          ra |         dec |       target | dispname |      decker | binning |               mjd | airmass | exptime | dichroic | calib | comb_id | bkg_id |
-| J1342_0928_K_longslit.5783.fits |          arc,science,tilt |  13.7020941 |  9.47416667 | J1342_0928_K |    K3000 | 4pixel-long |     1,1 | 57853.38282407408 |   1.143 | 300.957 |    Kspec |     0 |       1 |      2 |
-| J1342_0928_K_longslit.5784.fits |          arc,science,tilt |  13.7020941 |  9.47416667 | J1342_0928_K |    K3000 | 4pixel-long |     1,1 | 57853.38652777778 |   1.152 | 300.957 |    Kspec |     0 |       2 |      1 |
-|                  flat.5498.fits | pixelflat,illumflat,trace | 11.63234099 | 15.76900833 |         flat |    K3000 | 4pixel-long |     1,1 | 57852.32407407407 |   1.163 |  10.327 |    Kspec |     0 |      -1 |     -1 |
-|                  flat.5499.fits | pixelflat,illumflat,trace | 11.63234099 | 15.76900833 |         flat |    K3000 | 4pixel-long |     1,1 |      57852.324375 |   1.164 |  10.327 |    Kspec |     0 |      -1 |     -1 |
+ path /Users/tim/MMT/PypeIt-development-suite/RAW_DATA/mmt_mmirs/K_K
+                       filename |                 frametype |          ra |         dec |       target | dispname |      decker | binning |               mjd | airmass | exptime | dichroic | dithpat | dithpos |             dithoff | frameno | calib | comb_id | bkg_id
+J1342_0928_K_longslit.5783.fits |          arc,science,tilt |  13.7020941 |  9.47416667 | J1342_0928_K |    K3000 | 4pixel-long |     1,1 | 57853.38282407408 |   1.143 | 300.957 |    Kspec |    None |    None | -34.601640561309736 |    5783 |     0 |       1 |      2
+J1342_0928_K_longslit.5784.fits |          arc,science,tilt |  13.7020941 |  9.47416667 | J1342_0928_K |    K3000 | 4pixel-long |     1,1 | 57853.38652777778 |   1.152 | 300.957 |    Kspec |    None |    None | -34.601640561309736 |    5784 |     0 |       2 |      1
+                 flat.5498.fits | pixelflat,illumflat,trace | 11.63234099 | 15.76900833 |         flat |    K3000 | 4pixel-long |     1,1 | 57852.32407407407 |   1.163 |  10.327 |    Kspec |    None |    None |  -34.60059405279803 |    5498 |     0 |      -1 |     -1
+                 flat.5499.fits | pixelflat,illumflat,trace | 11.63234099 | 15.76900833 |         flat |    K3000 | 4pixel-long |     1,1 |      57852.324375 |   1.164 |  10.327 |    Kspec |    None |    None |  -34.60059405279803 |    5499 |     0 |      -1 |     -1
 data end
-

--- a/pypeit_files/mmt_mmirs_nep_as1_mos.pypeit
+++ b/pypeit_files/mmt_mmirs_nep_as1_mos.pypeit
@@ -1,0 +1,32 @@
+# Auto-generated PypeIt file
+# MMIRS multi-object (MOS) mask "nep.as1": exercises .msk mask-design ingest
+# (maskdef object assignment is auto-enabled by the nep.as1.msk file that sits
+# next to the frames) together with the geometry-driven A-B nod pairing.  This
+# is a subset (one ABA'B' cycle) of the full nep.as1 sequence; the two 300.957s
+# darks calibrate the up-the-ramp read noise at the science exposure time.
+
+# User-defined execution parameters
+[rdx]
+    spectrograph = mmt_mmirs
+
+# Setup
+setup read
+Setup A:
+  decker: nep.as1
+  dichroic: zJ
+  dispname: J
+setup end
+
+# Data block
+data read
+ path /Users/tim/MMT/PypeIt-development-suite/RAW_DATA/mmt_mmirs/nep_as1_MOS
+             filename |                 frametype |          ra |         dec |  target | dispname |  decker | binning |                mjd | airmass | exptime | dichroic | dithpat | dithpos |                 dithoff | frameno | calib
+nep.as1_mos.1822.fits |          arc,science,tilt | 17.37428881 | 65.88261431 | nep.as1 |        J | nep.as1 |     1,1 |   58739.1016087963 |   1.231 | 300.957 |       zJ |  ABA'B' |       A |      1.7999350315011449 |    1822 |     0
+nep.as1_mos.1823.fits |          arc,science,tilt | 17.37425438 | 65.88347776 | nep.as1 |        J | nep.as1 |     1,1 |  58739.10528935185 |   1.235 | 300.957 |       zJ |  ABA'B' |       B |     -1.3999629081282063 |    1823 |     0
+nep.as1_mos.1824.fits |          arc,science,tilt | 17.37428451 | 65.88272224 | nep.as1 |        J | nep.as1 |     1,1 | 58739.108935185184 |   1.239 | 300.957 |       zJ |  ABA'B' |      A' |      1.3999709854953284 |    1824 |     0
+nep.as1_mos.1825.fits |          arc,science,tilt | 17.37425008 | 65.88358569 | nep.as1 |        J | nep.as1 |     1,1 |  58739.11258101852 |   1.243 | 300.957 |       zJ |  ABA'B' |      B' |     -1.7999254494805157 |    1825 |     0
+       dark.2145.fits |                      dark |        -1.0 |      -100.0 |    Dark |     open |    dark |     1,1 |  58739.54199074074 |     1.0 | 300.957 |     dark |    None |    None |                     0.0 |    2145 |     0
+       dark.2146.fits |                      dark |        -1.0 |      -100.0 |    Dark |     open |    dark |     1,1 |       58739.545625 |     1.0 | 300.957 |     dark |    None |    None |                     0.0 |    2146 |     0
+       flat.1848.fits | pixelflat,illumflat,trace | 17.37426944 |     65.8831 |    flat |        J | nep.as1 |     1,1 |  58739.18989583333 |   1.411 |  10.327 |       zJ |    None |    None | -2.3088913330677472e-05 |    1848 |     0
+       flat.1849.fits | pixelflat,illumflat,trace | 17.37426944 |     65.8831 |    flat |        J | nep.as1 |     1,1 |  58739.19012731482 |   1.411 |  10.327 |       zJ |    None |    None | -2.3088913330677472e-05 |    1849 |     0
+data end

--- a/test_scripts/setups.py
+++ b/test_scripts/setups.py
@@ -243,6 +243,8 @@ all_setups = {
         'G270_Sky',
     ],
     'mmt_mmirs': [
+        'H3000_H',
+        'HK_HK3',
         'HK_zJ',
         'J_zJ',
         'K_K',

--- a/test_scripts/setups.py
+++ b/test_scripts/setups.py
@@ -246,6 +246,7 @@ all_setups = {
         'HK_zJ',
         'J_zJ',
         'K_K',
+        'nep_as1_MOS',
     ],
     'mmt_bluechannel': [
         '300l',


### PR DESCRIPTION
Updates the MMIRS dev-suite coverage to match the `mmirs_updates` branch of the main repo (PypeIt PR pypeit/PypeIt#2166: up-the-ramp fitting, geometry-driven A-B nod pairing, `.msk` mask-design ingest, and wavelength support for the remaining recommended long-slit modes).

## Regenerated long-slit setups

The three `mmt_mmirs` long-slit pypeit files are regenerated for the current code. They gain the derived dither columns (`dithpat`, `dithpos`, `dithoff`, `frameno`) and rely on the geometry-driven `get_comb_group` for A-B nod pairing:

- **`J_zJ`** and **`HK_zJ`** drop their hand-set `comb_id`/`bkg_id` — the real along-slit nods now auto-pair identically (`J_zJ` science A/B; `HK_zJ` standard-star A/B, single-frame science reduced as a stare).
- **`K_K`** keeps explicit `comb_id`/`bkg_id`: its two science frames share a pointing (a stare that cannot auto-pair), so pinning the groups preserves the historical A-B reduction and exercises the user-override path (auto-pairing is correctly skipped when the user sets the groups).

## New MOS test: `nep_as1_MOS`

A new setup exercising the MMIRS multi-object (MOS) path — the first dev-suite coverage of `.msk` mask-design ingest. It is a subset (one `ABA'B'` cycle) of the `nep.as1` mask sequence:

- 4 science frames (`nep.as1_mos.1822`–`1825`), 2 exposure-time-matched darks (`dark.2145`, `2146`), 2 flats (`flat.1848`, `1849`), plus the mask file `nep.as1.msk`.

It exercises, together in one reduction:
- `.msk` mask-design ingest and maskdef object assignment (`MASKDEF_ID`/`MASKDEF_OBJNAME`);
- the geometry-driven A-B nod pairing (reciprocal `ABA'B'`); and
- the matched-dark up-the-ramp read-noise calibration.

**Verified end to end** locally: the reduction completes with 4 spec2d + 4 spec1d, and 22 objects carry real `MASKDEF_ID`/`MASKDEF_OBJNAME`.

## New long-slit modes: `H3000_H` and `HK_HK3`

Two new setups extend coverage to the remaining observatory-recommended grism/filter modes (PypeIt PR pypeit/PypeIt#2166), each a 2-frame A-B nod (long-slit) + one exposure-matched dark + two flats:

- **`H3000_H`** — `WNTR25gkqzi` (frostig), the `H3000`/`H` mode.
- **`HK_HK3`** — the supernova `SN2026ejy` (bhsu), the `HK`/`HK3` mode.

Both use the new `full_template` wavelength arxiv templates added in #2166 and were reduced end to end locally (2 spec2d + 2 spec1d each, with correct H-band and H+K-band wavelengths). They are also the **first post-2019 sexagesimal-header** MMIRS data in the Dev Suite, so they exercise deriving the dither offset from the newer header format (all pre-existing MMIRS Dev Suite data is decimal).

## Raw data

The raw frames for the new MOS setup are now in the Dev Suite at `RAW_DATA/mmt_mmirs/nep_as1_MOS/` — the 8 FITS files listed above plus `nep.as1.msk`. The `.msk` must sit next to the frames, since MMIRS discovers it as `<decker>.msk`. The `H3000_H` and `HK_HK3` data (5 FITS files each) are likewise in the Drive at `RAW_DATA/mmt_mmirs/H3000_H/` and `RAW_DATA/mmt_mmirs/HK_HK3/`. Everything else in this PR is text (`pypeit_files/*` and `test_scripts/setups.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

